### PR TITLE
chore: drop client directives from deck.gl utilities

### DIFF
--- a/humans-globe-viz/components/globe/BasemapLayer.tsx
+++ b/humans-globe-viz/components/globe/BasemapLayer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { GeoJsonLayer } from '@deck.gl/layers';
 
 interface BasemapLayerProps {

--- a/humans-globe-viz/components/globe/HumanDotsLayer.tsx
+++ b/humans-globe-viz/components/globe/HumanDotsLayer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { ScatterplotLayer } from '@deck.gl/layers';
 
 interface HumanDot {


### PR DESCRIPTION
## Summary
- remove unneeded `'use client'` directives from BasemapLayer and HumanDotsLayer

## Testing
- `pnpm build` *(fails: Argument of type '[number, number, number, number] | null' is not assignable to parameter of type 'number[] | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_688f07c78abc8323a70924d7e7bae0e2