### PR TITLE
refactor: centralize target years

### DIFF
--- a/humans-globe-viz/components/TimeSlider.tsx
+++ b/humans-globe-viz/components/TimeSlider.tsx
@@ -4,22 +4,12 @@ import Slider from 'rc-slider';
 import { useMemo, useState, useEffect } from 'react';
 import 'rc-slider/assets/index.css';
 import { formatYear, sliderToYear, yearToSlider } from '../lib/useYear';
+import { TARGET_YEARS } from '../lib/constants';
 
 interface TimeSliderProps {
   value: number;
   onChange: (value: number) => void;
 }
-
-// Available target years (must match lib/useYear.ts)
-// Complete deep history dataset - 26 time periods 
-const TARGET_YEARS = [
-  // Deep Prehistory - Every millennium
-  -10000, -9000, -8000, -7000, -6000, -5000, -4000, -3000, -2000, -1000,
-  // Classical Period - Complete coverage every century
-  0, 100, 200, 300, 400, 500, 600, 700, 800, 900,
-  // Medieval Period
-  1000, 1100, 1200, 1300, 1400, 1500
-];
 
 // Helper to format individual year label
 // If `compact` is true, use a shortened representation to save space on narrow screens

--- a/humans-globe-viz/lib/constants.ts
+++ b/humans-globe-viz/lib/constants.ts
@@ -1,0 +1,13 @@
+// Available target years from HYDE 3.5 data (matches process_hyde.py TARGET_YEARS)
+// Complete deep history dataset - 26 time periods from Ice Age to Renaissance
+export const TARGET_YEARS = [
+  // Deep Prehistory - Every millennium
+  -10000, -9000, -8000, -7000, -6000, -5000, -4000, -3000, -2000, -1000,
+
+  // Classical Period - Complete coverage every century
+  0, 100, 200, 300, 400, 500, 600, 700, 800, 900,
+
+  // Medieval Period
+  1000, 1100, 1200, 1300, 1400, 1500,
+];
+

--- a/humans-globe-viz/lib/useYear.ts
+++ b/humans-globe-viz/lib/useYear.ts
@@ -1,19 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-
-// Available target years from HYDE 3.5 data (matches process_hyde.py TARGET_YEARS)
-// Complete deep history dataset - 26 time periods from Ice Age to Renaissance
-const TARGET_YEARS = [
-  // Deep Prehistory - Every millennium
-  -10000, -9000, -8000, -7000, -6000, -5000, -4000, -3000, -2000, -1000,
-  
-  // Classical Period - Complete coverage every century
-  0, 100, 200, 300, 400, 500, 600, 700, 800, 900,
-  
-  // Medieval Period  
-  1000, 1100, 1200, 1300, 1400, 1500
-];
+import { TARGET_YEARS } from './constants';
 
 // Data range constants (based on our available HYDE 3.3 data)
 const MIN_YEAR = TARGET_YEARS[0]; // -10000 BCE


### PR DESCRIPTION
## Summary
- centralize historical TARGET_YEARS into a dedicated lib/constants module
- consume TARGET_YEARS from constants in useYear hook and TimeSlider component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type error in components/globe/layers.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688f0775077c8323bd135b986077acba