### PR TITLE
refactor: import slider styles globally

### DIFF
--- a/humans-globe-viz/app/globals.css
+++ b/humans-globe-viz/app/globals.css
@@ -1,3 +1,4 @@
+@import 'rc-slider/assets/index.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/humans-globe-viz/components/TimeSlider.tsx
+++ b/humans-globe-viz/components/TimeSlider.tsx
@@ -2,7 +2,6 @@
 
 import Slider from 'rc-slider';
 import { useMemo, useState, useEffect } from 'react';
-import 'rc-slider/assets/index.css';
 import { formatYear, sliderToYear, yearToSlider } from '../lib/useYear';
 
 interface TimeSliderProps {


### PR DESCRIPTION
## Summary
- move rc-slider stylesheet import from TimeSlider component into global styles
- ensure global styles include rc-slider assets

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*
- `pnpm build --no-lint` *(fails: TypeScript error in components/Globe.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688f07762e5c8323b1c150cd1161b5d9