### PR TITLE
feat: split home page client logic

### DIFF
--- a/humans-globe-viz/app/page.tsx
+++ b/humans-globe-viz/app/page.tsx
@@ -1,35 +1,7 @@
-'use client';
+import dynamic from 'next/dynamic';
 
-import { useYear } from '../lib/useYear';
-import Globe from '../components/Globe';
-import SimpleGlobe from '../components/SimpleGlobe';
-import MinimalTest from '../components/MinimalTest';
-import TimeSlider from '../components/TimeSlider';
-import { ErrorBoundary } from '../components/ErrorBoundary';
+const HomeClient = dynamic(() => import('../components/HomeClient'), { ssr: false });
 
 export default function Home() {
-  const { year, sliderValue, updateSlider } = useYear(0); // Start at 0 CE (we know this data exists)
-  
-  return (
-    <main className="relative w-full h-screen overflow-hidden bg-black">
-      <ErrorBoundary>
-        {/* Globe visualization - now with React 18 compatibility */}
-        <Globe year={year} />
-      </ErrorBoundary>
-      
-      {/* Time control slider */}
-      <TimeSlider 
-        value={sliderValue} 
-        onChange={updateSlider}
-      />
-      
-      {/* Branding indicator - only show when not loading */}
-      {/* <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none">
-        <div className="text-white/50 text-center">
-          <div className="text-2xl font-bold mb-2">Globe of Humans</div>
-          <div className="text-sm">React 18 Compatible</div>
-        </div>
-      </div> */}
-    </main>
-  );
+  return <HomeClient />;
 }

--- a/humans-globe-viz/components/HomeClient.tsx
+++ b/humans-globe-viz/components/HomeClient.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useYear } from '../lib/useYear';
+import TimeSlider from './TimeSlider';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const Globe = dynamic(() => import('./Globe'), { ssr: false });
+
+export default function HomeClient() {
+  const { year, sliderValue, updateSlider } = useYear(0);
+
+  return (
+    <main className="relative w-full h-screen overflow-hidden bg-black">
+      <ErrorBoundary>
+        <Globe year={year} />
+      </ErrorBoundary>
+
+      <TimeSlider value={sliderValue} onChange={updateSlider} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create HomeClient client component encapsulating year state, globe, and slider
- render HomeClient from server-side `app/page.tsx` via dynamic import

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for interactive ESLint configuration)*
- `npm run build` *(fails: `ssr: false` is not allowed with `next/dynamic` in Server Components)*

------
https://chatgpt.com/codex/tasks/task_e_688f0793f3488323afea75fee37e0304