### PR TITLE
feat: constrain point generation to land

### DIFF
--- a/footstep-generator/landmask.py
+++ b/footstep-generator/landmask.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Lightweight land/sea mask utilities using Natural Earth polygons."""
+from __future__ import annotations
+
+import geopandas as gpd
+from shapely.geometry import Point
+from shapely.prepared import prep
+import io
+import requests
+
+response = requests.get(
+    "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_land.geojson",
+    timeout=30,
+)
+response.raise_for_status()
+_LAND_GEOMETRY = prep(gpd.read_file(io.BytesIO(response.content)).unary_union)
+
+def is_land(lat: float, lon: float) -> bool:
+    """Return True if the given latitude/longitude lies on land."""
+    return _LAND_GEOMETRY.contains(Point(lon, lat))

--- a/footstep-generator/lod_processor.py
+++ b/footstep-generator/lod_processor.py
@@ -7,6 +7,7 @@ Implements hierarchical spatial aggregation for performance optimization.
 import numpy as np
 from collections import defaultdict
 from typing import List, Dict, Optional
+from landmask import is_land
 from models import (
     LODLevel, Coordinates, HumanSettlement, AggregatedSettlement, 
     LODConfiguration, ProcessingStatistics, SettlementContinuityConfig
@@ -225,8 +226,13 @@ class LODProcessor:
             population_per_dot = cell_population / num_dots  # Use actual population, not fixed amount
             
             for _ in range(num_dots):
-                dot_lat = lat + np.random.uniform(-cellsize/2, cellsize/2)
-                dot_lon = lon + np.random.uniform(-cellsize/2, cellsize/2)
+                attempts = 0
+                while True:
+                    dot_lat = lat + np.random.uniform(-cellsize/2, cellsize/2)
+                    dot_lon = lon + np.random.uniform(-cellsize/2, cellsize/2)
+                    if is_land(dot_lat, dot_lon) or attempts >= 10:
+                        break
+                    attempts += 1
                 dots.append((dot_lat, dot_lon, population_per_dot))
                 
         elif settlement_type == "town":
@@ -250,11 +256,15 @@ class LODProcessor:
                     offset_lon = (j - grid_size/2 + 0.5) * grid_step
                     
                     # Add small random offset to avoid perfect grid
-                    offset_lat += np.random.uniform(-grid_step/4, grid_step/4)
-                    offset_lon += np.random.uniform(-grid_step/4, grid_step/4)
-                    
-                    dot_lat = lat + offset_lat
-                    dot_lon = lon + offset_lon
+                    attempts = 0
+                    while True:
+                        pert_lat = np.random.uniform(-grid_step/4, grid_step/4)
+                        pert_lon = np.random.uniform(-grid_step/4, grid_step/4)
+                        dot_lat = lat + offset_lat + pert_lat
+                        dot_lon = lon + offset_lon + pert_lon
+                        if is_land(dot_lat, dot_lon) or attempts >= 10:
+                            break
+                        attempts += 1
                     dots.append((dot_lat, dot_lon, population_per_dot))
                     dot_idx += 1
                     
@@ -276,6 +286,14 @@ class LODProcessor:
                 offset_lat, offset_lon = positions[i]
                 dot_lat = lat + offset_lat * cellsize
                 dot_lon = lon + offset_lon * cellsize
+                if not is_land(dot_lat, dot_lon):
+                    attempts = 0
+                    while True:
+                        dot_lat = lat + np.random.uniform(-cellsize/2, cellsize/2)
+                        dot_lon = lon + np.random.uniform(-cellsize/2, cellsize/2)
+                        if is_land(dot_lat, dot_lon) or attempts >= 10:
+                            break
+                        attempts += 1
                 dots.append((dot_lat, dot_lon, population_per_dot))
         
         return dots

--- a/footstep-generator/process_cities.py
+++ b/footstep-generator/process_cities.py
@@ -8,6 +8,7 @@ import pathlib
 import pandas as pd
 import numpy as np
 from typing import List, Dict, Any, Tuple
+from landmask import is_land
 
 # Population estimation parameters - consistent with HYDE processing
 PERSONS_PER_DOT = 100  # Always 100 people per dot for consistency
@@ -189,14 +190,17 @@ def add_rural_population(dots: List[Dict], year: int, total_world_pop: int) -> L
     persons_per_dot = get_persons_per_dot(year)
     num_rural_dots = min(rural_pop // persons_per_dot, 5000)  # Limit for performance
 
-    for _ in range(num_rural_dots):
+    accepted = 0
+    while accepted < num_rural_dots:
         region = np.random.choice(len(INHABITABLE_REGIONS), p=REGION_PROBABILITIES)
         lat_min, lat_max, lon_min, lon_max, _ = INHABITABLE_REGIONS[region]
-        
-        # Random point in this region
+
         rural_lat = np.random.uniform(lat_min, lat_max)
         rural_lon = np.random.uniform(lon_min, lon_max)
-        
+
+        if not is_land(rural_lat, rural_lon):
+            continue
+
         dots.append({
             'lat': rural_lat,
             'lon': rural_lon,
@@ -205,6 +209,7 @@ def add_rural_population(dots: List[Dict], year: int, total_world_pop: int) -> L
             'city': 'rural',
             'type': 'rural'
         })
+        accepted += 1
     
     return dots
 

--- a/footstep-generator/tests/test_land_mask.py
+++ b/footstep-generator/tests/test_land_mask.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from landmask import is_land
+from lod_processor import LODProcessor
+from settlement_registry import SettlementRegistry
+from process_cities import add_rural_population
+
+
+def test_random_dots_on_land():
+    processor = LODProcessor()
+    np.random.seed(0)
+    for settlement_type in ['rural', 'town', 'city']:
+        dots = processor._create_random_dots(1000, 51.5, 0.0, 1.0, 100, settlement_type)
+        assert dots
+        for lat, lon, _ in dots:
+            assert is_land(lat, lon)
+
+
+def test_deterministic_positions_on_land():
+    registry = SettlementRegistry()
+    for settlement_type in ['rural', 'town', 'city']:
+        positions = registry._generate_deterministic_positions(51.5, 0.0, 1.0, 5, 'cell', settlement_type)
+        for pos in positions:
+            assert is_land(pos.coordinates.latitude, pos.coordinates.longitude)
+
+
+def test_rural_population_on_land():
+    np.random.seed(0)
+    dots = add_rural_population([], 2000, 1000)
+    rural_dots = [d for d in dots if d['type'] == 'rural']
+    assert rural_dots
+    for dot in rural_dots:
+        assert is_land(dot['lat'], dot['lon'])


### PR DESCRIPTION
## Summary
- load Natural Earth land polygons at startup and expose `is_land`
- resample settlement and rural dots until they fall on land
- add tests verifying generated coordinates lie on land

## Testing
- `poetry run pytest footstep-generator/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896f3eb3fd88323bef300dbceb9fe4b