### PR TITLE
refactor: centralize human dot render limit

### DIFF
--- a/humans-globe/components/FootstepsViz.tsx
+++ b/humans-globe/components/FootstepsViz.tsx
@@ -9,7 +9,7 @@ import LegendOverlay from './globe/LegendOverlay';
 import PopulationTooltip from './PopulationTooltip';
 import GlobeView3D from './GlobeView3D';
 import MapView2D from './MapView2D';
-import useHumanDotsData, { MAX_RENDER_DOTS } from './globe/useHumanDotsData';
+import useHumanDotsData from './globe/useHumanDotsData';
 import useGlobeViewState from './globe/useGlobeViewState';
 // import { scaleSequential } from 'd3-scale';
 // import * as d3 from 'd3-scale';
@@ -446,13 +446,6 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     return createBasemapLayer(basemapData, basemapError);
   }, [basemapData, basemapError]);
   
-  // Prepare dots for rendering with hard performance limit
-  const dotsToRender = useMemo(() => {
-    return visibleHumanDots.length > MAX_RENDER_DOTS 
-      ? visibleHumanDots.slice(0, MAX_RENDER_DOTS)
-      : visibleHumanDots;
-  }, [visibleHumanDots]);
-  
   // Stable LOD level for memoization - only changes at discrete boundaries
   const stableLODLevel = useMemo(() => {
     return getLODLevel(viewState.zoom);
@@ -475,10 +468,10 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     const radiusStrategy = is3DMode ? radiusStrategies.globe3D : radiusStrategies.zoomAdaptive;
     
     return createHumanDotsLayer(
-      dotsToRender, 
-      layerViewState, 
-      year, 
-      stableLODLevel, 
+      visibleHumanDots,
+      layerViewState,
+      year,
+      stableLODLevel,
       radiusStrategy,
       (info: any) => {
         if (info.object) {
@@ -514,7 +507,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         }
       }
     );
-  }, [dotsToRender, layerViewState, year, stableLODLevel, is3DMode]);
+  }, [visibleHumanDots, layerViewState, year, stableLODLevel, is3DMode]);
   
   
   // Memoized layers array to prevent array recreation
@@ -554,21 +547,21 @@ function FootstepsViz({ year }: FootstepsVizProps) {
       {/* Data info overlay */}
       <HumanDotsOverlay
         loading={loading}
-          dotCount={dotsToRender.length}
-          totalPopulation={totalPopulation}
-          viewState={viewState}
-          samplingRate={samplingRate}
-          lodEnabled={true} // Always enabled with server-side LOD
-          toggleLOD={() => {}} // No-op since LOD is server-controlled
-          renderMetrics={renderMetrics}
-          cacheSize={dataCache.size}
-          progressiveRenderStatus={
-            dotsToRender.length < visibleHumanDots.length 
-              ? { rendered: dotsToRender.length, total: visibleHumanDots.length }
-              : undefined
-          }
-          viewportBounds={viewportBounds}
-          is3DMode={is3DMode}
+        dotCount={visibleHumanDots.length}
+        totalPopulation={totalPopulation}
+        viewState={viewState}
+        samplingRate={samplingRate}
+        lodEnabled={true} // Always enabled with server-side LOD
+        toggleLOD={() => {}} // No-op since LOD is server-controlled
+        renderMetrics={renderMetrics}
+        cacheSize={dataCache.size}
+        progressiveRenderStatus={
+          visibleHumanDots.length < humanDotsData.length
+            ? { rendered: visibleHumanDots.length, total: humanDotsData.length }
+            : undefined
+        }
+        viewportBounds={viewportBounds}
+        is3DMode={is3DMode}
       />
       
       {/* View Mode Toggle */}


### PR DESCRIPTION
## Summary
- remove redundant `dotsToRender` memo and constant import
- pass `visibleHumanDots` straight to `createHumanDotsLayer`
- report render status using hook-truncated data only

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator` *(fails: assert 1.0 == 2.0)*

------
https://chatgpt.com/codex/tasks/task_e_689730de208c8323b0b90f41d6c4c28c