### PR TITLE
fix: replace hover console log with callback

### DIFF
--- a/humans-globe/components/globe/HumanDotsLayer.tsx
+++ b/humans-globe/components/globe/HumanDotsLayer.tsx
@@ -17,9 +17,15 @@ interface HumanDotsLayerProps {
   data: HumanDot[];
   viewState: any;
   onClick?: (info: any) => void;
+  onHover?: (info: any) => void;
 }
 
-export function createHumanDotsLayer({ data, viewState, onClick }: HumanDotsLayerProps) {
+export function createHumanDotsLayer({
+  data,
+  viewState,
+  onClick,
+  onHover,
+}: HumanDotsLayerProps) {
   return new ScatterplotLayer({
     id: 'human-dots',
     data,
@@ -43,7 +49,7 @@ export function createHumanDotsLayer({ data, viewState, onClick }: HumanDotsLaye
     },
     getFillColor: (d: any) => {
       const population = d?.properties?.population || 100;
-      
+
       // Color intensity based on population
       if (population > 20000) {
         return [255, 100, 0, 240]; // Large settlements: bright red-orange
@@ -55,11 +61,7 @@ export function createHumanDotsLayer({ data, viewState, onClick }: HumanDotsLaye
         return [255, 200, 100, 180]; // Very small settlements: pale orange
       }
     },
-    onHover: (info: any) => {
-      if (info.object) {
-        console.log('Hovered dot:', info.object);
-      }
-    },
+    onHover: onHover || (() => {}),
     onClick: onClick || (() => {}),
   });
 }


### PR DESCRIPTION
## Summary
- remove console logging from `HumanDotsLayer` hover handler
- allow passing optional `onHover` callback for hover feedback

## Testing
- `pnpm lint` (failed: warnings)
- `pnpm test`
- `poetry run pytest footstep-generator` (failed: 2 failed, 61 passed)


------
https://chatgpt.com/codex/tasks/task_e_68973115f7ac8323b68e2676eff41909