### PR TITLE
refactor: streamline human dot schema

### DIFF
--- a/humans-globe/components/FootstepsViz.tsx
+++ b/humans-globe/components/FootstepsViz.tsx
@@ -292,7 +292,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
 
   const totalPopulation = useMemo(() => {
     return humanDotsData.reduce((sum, dot) => {
-      return sum + (dot?.properties?.population ?? 0);
+      return sum + (dot?.population ?? 0);
     }, 0);
   }, [humanDotsData]);
 
@@ -475,23 +475,23 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     const radiusStrategy = is3DMode ? radiusStrategies.globe3D : radiusStrategies.zoomAdaptive;
     
     return createHumanDotsLayer(
-      dotsToRender, 
-      layerViewState, 
-      year, 
-      stableLODLevel, 
+      dotsToRender,
+      layerViewState,
+      year,
+      stableLODLevel,
       radiusStrategy,
       (info: any) => {
         if (info.object) {
           const dot = info.object;
-          const population = dot.properties?.population || 0;
-          const coordinates = dot.geometry?.coordinates as [number, number] || [0, 0];
-          
+          const population = dot.population || 0;
+          const coordinates = (dot.coords as [number, number]) || [0, 0];
+
           // Get click position in screen coordinates
           const clickPosition = {
             x: info.x || 0,
             y: info.y || 0
           };
-          
+
           // Set tooltip data
           setTooltipData({
             population,
@@ -504,8 +504,8 @@ function FootstepsViz({ year }: FootstepsVizProps) {
       (info: any) => {
         if (info && info.object) {
           const dot = info.object;
-          const population = dot.properties?.population || 0;
-          const coordinates = dot.geometry?.coordinates as [number, number] || [0, 0];
+          const population = dot.population || 0;
+          const coordinates = (dot.coords as [number, number]) || [0, 0];
           const clickPosition = { x: info.x || 0, y: info.y || 0 };
           setTooltipData({ population, coordinates, year, clickPosition });
         } else {

--- a/humans-globe/components/globe/HumanDotsLayer.tsx
+++ b/humans-globe/components/globe/HumanDotsLayer.tsx
@@ -1,16 +1,9 @@
 import { ScatterplotLayer } from '@deck.gl/layers';
 
 interface HumanDot {
-  type: string;
-  geometry: {
-    type: string;
-    coordinates: [number, number];
-  };
-  properties: {
-    population: number;
-    year: number;
-    type: string;
-  };
+  coords: [number, number];
+  population: number;
+  radius: number;
 }
 
 interface HumanDotsLayerProps {
@@ -25,11 +18,11 @@ export function createHumanDotsLayer({ data, viewState, onClick }: HumanDotsLaye
     data,
     pickable: true,
     radiusUnits: 'meters', // Use meters for GPU-accelerated scaling
-    getPosition: (d: any) => {
+    getPosition: (d: HumanDot) => {
       try {
-        const coords = d.geometry?.coordinates;
+        const coords = d.coords;
         if (!coords || !Array.isArray(coords) || coords.length !== 2) {
-          return [0, 0] as [number, number]; // Fallback to origin if invalid
+          return [0, 0] as [number, number];
         }
         return coords as [number, number];
       } catch (error) {
@@ -38,11 +31,11 @@ export function createHumanDotsLayer({ data, viewState, onClick }: HumanDotsLaye
       }
     },
     // Use pre-computed radius values for optimal performance
-    getRadius: (d: any) => {
-      return d?.properties?.precomputedRadius || 2000; // Default to village size (2km)
+    getRadius: (d: HumanDot) => {
+      return d?.radius || 2000; // Default to village size (2km)
     },
-    getFillColor: (d: any) => {
-      const population = d?.properties?.population || 100;
+    getFillColor: (d: HumanDot) => {
+      const population = d?.population || 100;
       
       // Color intensity based on population
       if (population > 20000) {

--- a/humans-globe/components/globe/layers.ts
+++ b/humans-globe/components/globe/layers.ts
@@ -133,7 +133,7 @@ export function createHumanDotsLayer(
   const layerId = `human-dots-${year}-lod${lodLevel || 'legacy'}-${radiusStrategy.getName()}`;
   
   const currentZoom = viewState?.zoom || 1;
-  
+
   return new ScatterplotLayer({
     id: layerId,
     data,
@@ -148,9 +148,9 @@ export function createHumanDotsLayer(
     radiusScale: 1, // Ensure dots are properly scaled
     getPosition: (d: any) => {
       try {
-        const coords = d.geometry?.coordinates;
+        const coords = d?.coords;
         if (!coords || !Array.isArray(coords) || coords.length !== 2) {
-          return [0, 0]; // Fallback to origin if invalid
+          return [0, 0];
         }
         // Let GlobeView handle the sphere projection
         return coords as [number, number];
@@ -160,11 +160,11 @@ export function createHumanDotsLayer(
     },
     // Use radius strategy for flexible calculation approach
     getRadius: (d: any) => {
-      const baseRadius = d?.properties?.precomputedRadius || 2000; // Default to village size (2km)
+      const baseRadius = d?.radius || 2000; // Default to village size (2km)
       return radiusStrategy.calculateRadius(baseRadius, currentZoom);
     },
     getFillColor: (d: any) => {
-      const population = d?.properties?.population || 100;
+      const population = d?.population || 100;
       
       // Color intensity based on population
       if (population > 20000) {

--- a/humans-globe/components/globe/useHumanDotsData.ts
+++ b/humans-globe/components/globe/useHumanDotsData.ts
@@ -1,16 +1,9 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 
 export interface HumanDot {
-  type: string;
-  geometry: {
-    type: string;
-    coordinates: [number, number];
-  };
-  properties: {
-    population: number;
-    year: number;
-    type: string;
-  };
+  coords: [number, number];
+  population: number;
+  radius: number;
 }
 
 export const DOT_LIMIT = 5000000;
@@ -94,7 +87,7 @@ export default function useHumanDotsData(
 
           const loadEndTime = performance.now();
           const data = await response.json();
-          const features = data.features || [];
+          const features = (data.features || []) as HumanDot[];
           const processEndTime = performance.now();
 
           dataCache.current.set(cacheKey, features);
@@ -128,10 +121,10 @@ export default function useHumanDotsData(
       }
 
       const validDots = humanDotsData.filter(dot => {
-        if (!dot || !dot.properties || !dot.geometry || !dot.geometry.coordinates) {
+        if (!dot || !dot.coords) {
           return false;
         }
-        const coords = dot.geometry.coordinates;
+        const coords = dot.coords;
         if (!Array.isArray(coords) || coords.length !== 2) {
           return false;
         }
@@ -149,9 +142,7 @@ export default function useHumanDotsData(
         return true;
       });
 
-      return validDots.sort(
-        (a, b) => (b.properties?.population || 0) - (a.properties?.population || 0)
-      );
+      return validDots.sort((a, b) => (b.population || 0) - (a.population || 0));
     } catch (err) {
       console.error('Error processing human dots data:', err);
       return [] as HumanDot[];


### PR DESCRIPTION
## Summary
- simplify human dot API response to `{coords, population, radius}` and drop metadata
- update data hook and layer utilities for leaner dot objects
- adjust rendering and tooltips to use new schema

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68973127ac708323935c867f26d7e20b