### PR TITLE
feat: add brotli compression support

### DIFF
--- a/humans-globe/components/globe/useHumanDotsData.ts
+++ b/humans-globe/components/globe/useHumanDotsData.ts
@@ -86,7 +86,12 @@ export default function useHumanDotsData(
           }
 
           const response = await fetch(
-            `/api/human-dots?year=${year}&limit=${DOT_LIMIT}&zoom=${zoom}${boundsQuery}`
+            `/api/human-dots?year=${year}&limit=${DOT_LIMIT}&zoom=${zoom}${boundsQuery}`,
+            {
+              headers: {
+                'Accept-Encoding': 'br, gzip'
+              }
+            }
           );
           if (!response.ok) {
             throw new Error('Failed to load human dots data');


### PR DESCRIPTION
## Summary
- Serve human dots data using Brotli when clients request it, with gzip fallback
- Request Brotli or gzip compression when fetching human dots data

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68973159bd8c8323ad709f22e6893807