### PR TITLE
perf: use itertuples for settlement conversion

### DIFF
--- a/footstep-generator/process_hyde.py
+++ b/footstep-generator/process_hyde.py
@@ -370,7 +370,7 @@ def process_year_with_hierarchical_lods(
     settlements = []
     cellsize = 0.083333  # HYDE 3.5 approximate resolution
 
-    for _, row in gdf.iterrows():
+    for row in gdf.itertuples(index=False):
         try:
             geom = row.geometry
             settlement = HumanSettlement(


### PR DESCRIPTION
## Summary
- use `gdf.itertuples()` to build `HumanSettlement` objects while converting HYDE dots

## Testing
- `poetry run pytest footstep-generator` *(fails: 2, passes: 61)*

------
https://chatgpt.com/codex/tasks/task_e_68973ab6f89083239b2bc50a07d46c10