### PR TITLE
feat: debounced flags for globe view interactions

### DIFF
--- a/humans-globe/components/footsteps/hooks/useDebouncedFlag.ts
+++ b/humans-globe/components/footsteps/hooks/useDebouncedFlag.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useDebouncedFlag(delay: number): [boolean, () => void] {
+  const [flag, setFlag] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const trigger = useCallback(() => {
+    setFlag(true);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setFlag(false);
+      timeoutRef.current = null;
+    }, delay);
+  }, [delay]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return [flag, trigger];
+}


### PR DESCRIPTION
## Summary
- add reusable `useDebouncedFlag` hook
- refactor globe view state to use debounced zoom/pan flags and refs for prev state

## Testing
- `pnpm lint`
- `pnpm exec prettier components/footsteps/hooks/useDebouncedFlag.ts components/footsteps/hooks/useGlobeViewState.ts --write`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `poetry run pip install numpy`

------
https://chatgpt.com/codex/tasks/task_e_68a44461f3a083239034e65c841361b6