### PR TITLE
refactor: extract slider hooks for reuse

### DIFF
--- a/humans-globe/components/ui/TimeSlider.tsx
+++ b/humans-globe/components/ui/TimeSlider.tsx
@@ -1,107 +1,20 @@
 'use client';
 
 import Slider from 'rc-slider';
-import { useMemo, useState, useEffect } from 'react';
-import { formatYear, sliderToYear, yearToSlider } from '@/lib/useYear';
-import { TARGET_YEARS } from '@/lib/constants';
+import { formatYear, sliderToYear } from '@/lib/useYear';
+import useSliderMarks from './hooks/useSliderMarks';
 
 interface TimeSliderProps {
   value: number;
   onChange: (value: number) => void;
 }
 
-// Helper to format individual year label
-// If `compact` is true, use a shortened representation to save space on narrow screens
-const formatLabel = (year: number, compact = false) => {
-  if (compact) {
-    // Show "10k" for -10_000, "9k" for -9_000, etc. Drop the BC suffix for brevity
-    if (year <= -1000 && year % 1000 === 0) return `${Math.abs(year / 1000)}k`;
-    if (year < 0) return `${Math.abs(year)}BC`; // e.g. -500 -> 500BC (no space)
-    if (year >= 1000 && year % 100 === 0) {
-      // 1000 -> 1k, 1200 -> 1.2k, 1500 -> 1.5k
-      return `${(year / 1000).toFixed(year % 1000 === 0 ? 0 : 1)}k`;
-    }
-    return year.toString();
-  }
-
-  // Full labels (default)
-  if (year < 0) return `${Math.abs(year)} BC`;
-  if (year === 0) return '0';
-  if (year >= 1000 && year % 1000 === 0 && year !== 1000) return `${year / 1000}k`;
-  return year.toString();
-};
-  
-// Determine which years to label based on available slider width and logarithmic scale
-// Ensures a minimum pixel spacing between labels to avoid overlap on medium screens
-const MIN_LABEL_SPACING_PX = 70;
-
-const getResponsiveYears = (width: number, currentYear: number): number[] => {
-  // Calculate minimum spacing in slider % units
-  const thresholdPercent = (MIN_LABEL_SPACING_PX / width) * 100;
-  const yearsSorted = [...TARGET_YEARS].sort((a, b) => a - b);
-  const selected: number[] = [];
-  yearsSorted.forEach((year) => {
-    const pos = yearToSlider(year);
-    const tooClose = selected.some((sel) => Math.abs(pos - yearToSlider(sel)) < thresholdPercent);
-    if (!tooClose) {
-      selected.push(year);
-    }
-  });
-  // Ensure the currentYear is always included
-  if (!selected.includes(currentYear)) {
-    selected.push(currentYear);
-    selected.sort((a,b)=>a-b);
-  }
-  return selected;
-};
-  
-// Generate dynamic marks emphasising the currently selected year
-// Determine viewport width once per resize – used to decide when to switch to compact labels
-const useWindowWidth = () => {
-  // Start with a neutral default that is the same for both server and client.
-  // The actual `window.innerWidth` will be populated after the first mount.
-  const [width, setWidth] = useState<number>(1024);
-  useEffect(() => {
-    const handleResize = () => setWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-  return width;
-};
-
-const useSliderMarks = (currentSliderValue: number) => {
-  const width = useWindowWidth();
-  const compact = width < 640; // Tailwind's sm breakpoint (640px)
-
-  return useMemo(() => {
-    const marks: Record<number, { label: string; style?: React.CSSProperties }> = {};
-    const currentYear = sliderToYear(currentSliderValue);
-    const keyYears = getResponsiveYears(width, currentYear);
-
-    keyYears.forEach((year: number) => {
-      if (!TARGET_YEARS.includes(year)) return;
-      const position = yearToSlider(year);
-      const isCurrent = Math.abs(currentSliderValue - position) < 0.05; // slider uses 0.1 step
-      marks[position] = {
-        label: formatLabel(year, compact),
-        style: {
-          color: isCurrent ? '#38bdf8' : '#f1f5f9',
-          fontWeight: isCurrent ? 600 : 400,
-          fontSize: compact ? '0.7rem' : undefined,
-        },
-      };
-    });
-    return marks;
-  }, [currentSliderValue, compact, width]);
-};
-
 export default function TimeSlider({ value, onChange }: TimeSliderProps) {
   const marks = useSliderMarks(value);
   const currentYear = sliderToYear(value);
 
-  
   return (
-    <div 
+    <div
       className="fixed bg-black/80 backdrop-blur-sm rounded-lg p-6"
       style={{ bottom: '2rem', left: '2rem', right: '2rem', zIndex: 40 }}
     >
@@ -112,14 +25,16 @@ export default function TimeSlider({ value, onChange }: TimeSliderProps) {
             {formatYear(currentYear)}
           </div>
         </div>
-        
+
         {/* Slider */}
         <div className="px-4 pb-8 w-full">
           <Slider
             min={0}
             max={100}
             value={value}
-            onChange={(value) => onChange(Array.isArray(value) ? value[0] : value)}
+            onChange={(value) =>
+              onChange(Array.isArray(value) ? value[0] : value)
+            }
             marks={marks}
             step={0.1}
             className="mb-8 w-full"
@@ -131,19 +46,18 @@ export default function TimeSlider({ value, onChange }: TimeSliderProps) {
               width: 24,
               height: 24,
               marginTop: -9,
-              boxShadow: '0 0 10px rgba(14, 165, 233, 0.5)'
+              boxShadow: '0 0 10px rgba(14, 165, 233, 0.5)',
             }}
             dotStyle={{
               backgroundColor: '#475569',
-              border: '2px solid #64748b'
+              border: '2px solid #64748b',
             }}
             activeDotStyle={{
               backgroundColor: '#0ea5e9',
-              border: '2px solid #38bdf8'
+              border: '2px solid #38bdf8',
             }}
           />
         </div>
-        
       </div>
     </div>
   );

--- a/humans-globe/components/ui/hooks/useSliderMarks.test.tsx
+++ b/humans-globe/components/ui/hooks/useSliderMarks.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, act, cleanup } from '@testing-library/react';
+import useSliderMarks from './useSliderMarks';
+import { yearToSlider } from '@/lib/useYear';
+
+function TestComponent({ value }: { value: number }) {
+  const marks = useSliderMarks(value);
+  return <div data-testid="marks">{JSON.stringify(marks)}</div>;
+}
+
+function getMarksForWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: width,
+  });
+  const sliderVal = yearToSlider(0);
+  const { getByTestId } = render(<TestComponent value={sliderVal} />);
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+  const marks = JSON.parse(getByTestId('marks').textContent as string);
+  cleanup();
+  return marks as Record<string, { label: string }>;
+}
+
+describe('useSliderMarks', () => {
+  const widths = [320, 768, 1024];
+  widths.forEach((width) => {
+    test(`ensures minimum spacing at width ${width}px`, () => {
+      const marks = getMarksForWidth(width);
+      const positions = Object.keys(marks)
+        .map(Number)
+        .sort((a, b) => a - b);
+      const currentPos = yearToSlider(0);
+      const filtered = positions.filter((p) => Math.abs(p - currentPos) > 0.01);
+      const threshold = (70 / width) * 100;
+      for (let i = 1; i < filtered.length; i++) {
+        expect(filtered[i] - filtered[i - 1]).toBeGreaterThanOrEqual(threshold);
+      }
+    });
+  });
+
+  test('renders more marks on wide viewports', () => {
+    const small = getMarksForWidth(320);
+    const large = getMarksForWidth(1280);
+    expect(Object.keys(large).length).toBeGreaterThan(
+      Object.keys(small).length,
+    );
+  });
+});

--- a/humans-globe/components/ui/hooks/useSliderMarks.ts
+++ b/humans-globe/components/ui/hooks/useSliderMarks.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useMemo } from 'react';
+import { sliderToYear, yearToSlider } from '@/lib/useYear';
+import { TARGET_YEARS } from '@/lib/constants';
+import useWindowWidth from './useWindowWidth';
+
+// Helper to format individual year label
+// If `compact` is true, use a shortened representation to save space on narrow screens
+const formatLabel = (year: number, compact = false) => {
+  if (compact) {
+    // Show "10k" for -10_000, "9k" for -9_000, etc. Drop the BC suffix for brevity
+    if (year <= -1000 && year % 1000 === 0) return `${Math.abs(year / 1000)}k`;
+    if (year < 0) return `${Math.abs(year)}BC`; // e.g. -500 -> 500BC (no space)
+    if (year >= 1000 && year % 100 === 0) {
+      // 1000 -> 1k, 1200 -> 1.2k, 1500 -> 1.5k
+      return `${(year / 1000).toFixed(year % 1000 === 0 ? 0 : 1)}k`;
+    }
+    return year.toString();
+  }
+
+  // Full labels (default)
+  if (year < 0) return `${Math.abs(year)} BC`;
+  if (year === 0) return '0';
+  if (year >= 1000 && year % 1000 === 0 && year !== 1000)
+    return `${year / 1000}k`;
+  return year.toString();
+};
+
+// Determine which years to label based on available slider width and logarithmic scale
+// Ensures a minimum pixel spacing between labels to avoid overlap on medium screens
+const MIN_LABEL_SPACING_PX = 70;
+
+const getResponsiveYears = (width: number, currentYear: number): number[] => {
+  // Calculate minimum spacing in slider % units
+  const thresholdPercent = (MIN_LABEL_SPACING_PX / width) * 100;
+  const yearsSorted = [...TARGET_YEARS].sort((a, b) => a - b);
+  const selected: number[] = [];
+  yearsSorted.forEach((year) => {
+    const pos = yearToSlider(year);
+    const tooClose = selected.some(
+      (sel) => Math.abs(pos - yearToSlider(sel)) < thresholdPercent,
+    );
+    if (!tooClose) {
+      selected.push(year);
+    }
+  });
+  // Ensure the currentYear is always included
+  if (!selected.includes(currentYear)) {
+    selected.push(currentYear);
+    selected.sort((a, b) => a - b);
+  }
+  return selected;
+};
+
+export default function useSliderMarks(currentSliderValue: number) {
+  const width = useWindowWidth();
+  const compact = width < 640; // Tailwind's sm breakpoint (640px)
+
+  return useMemo(() => {
+    const marks: Record<
+      number,
+      { label: string; style?: React.CSSProperties }
+    > = {};
+    const currentYear = sliderToYear(currentSliderValue);
+    const keyYears = getResponsiveYears(width, currentYear);
+
+    keyYears.forEach((year: number) => {
+      if (!TARGET_YEARS.includes(year)) return;
+      const position = yearToSlider(year);
+      const isCurrent = Math.abs(currentSliderValue - position) < 0.05; // slider uses 0.1 step
+      marks[position] = {
+        label: formatLabel(year, compact),
+        style: {
+          color: isCurrent ? '#38bdf8' : '#f1f5f9',
+          fontWeight: isCurrent ? 600 : 400,
+          fontSize: compact ? '0.7rem' : undefined,
+        },
+      };
+    });
+    return marks;
+  }, [currentSliderValue, compact, width]);
+}

--- a/humans-globe/components/ui/hooks/useWindowWidth.ts
+++ b/humans-globe/components/ui/hooks/useWindowWidth.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function useWindowWidth() {
+  // Start with a neutral default that is the same for both server and client.
+  // The actual `window.innerWidth` will be populated after the first mount.
+  const [width, setWidth] = useState<number>(1024);
+
+  useEffect(() => {
+    const handleResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return width;
+}


### PR DESCRIPTION
## Summary
- extract window width and slider mark hooks for reuse
- streamline `TimeSlider` component
- add tests for responsive slider labels

## Testing
- `pnpm lint`
- `pnpm prettier components/ui/TimeSlider.tsx components/ui/hooks/useSliderMarks.ts components/ui/hooks/useWindowWidth.ts components/ui/hooks/useSliderMarks.test.tsx --write`
- `pnpm test`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4443fdbf483238a643731b239a9af