### PR TITLE
feat: extract year crossfade hook

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { useState, useMemo, useEffect, memo, useCallback, useRef } from 'react';
+import { useState, useMemo, useEffect, memo, useCallback } from 'react';
 import { getViewMode, setViewMode } from '@/lib/viewModeStore';
 import { getLODLevel } from '@/lib/lod';
-import { createHumanTilesLayer, createStaticTerrainLayer, createPlainBackgroundLayers, radiusStrategies } from '@/components/footsteps/layers/layers';
+import {
+  createHumanTilesLayer,
+  createStaticTerrainLayer,
+  createPlainBackgroundLayers,
+  radiusStrategies,
+} from '@/components/footsteps/layers/layers';
 import { type LayersList } from '@deck.gl/core';
 import SupportingText from '@/components/footsteps/overlays/SupportingText';
 import LegendOverlay from '@/components/footsteps/overlays/LegendOverlay';
@@ -11,10 +16,17 @@ import PopulationTooltip from '@/components/footsteps/overlays/PopulationTooltip
 import GlobeView3D from '@/components/footsteps/views/GlobeView3D';
 import MapView2D from '@/components/footsteps/views/MapView2D';
 import useGlobeViewState from '@/components/footsteps/hooks/useGlobeViewState';
+import useYearCrossfade, {
+  YEAR_FADE_MS,
+  NEW_YEAR_FADE_MS,
+} from '@/components/footsteps/hooks/useYearCrossfade';
 import VizToggles from '@/components/ui/VizToggles';
 
 type PickingInfo = {
-  object?: { properties?: { population?: number }; geometry?: { coordinates?: [number, number] } };
+  object?: {
+    properties?: { population?: number };
+    geometry?: { coordinates?: [number, number] };
+  };
   x?: number;
   y?: number;
 };
@@ -26,13 +38,14 @@ interface FootstepsVizProps {
 function FootstepsViz({ year }: FootstepsVizProps) {
   // View mode toggle state with cookie persistence for SSR compatibility
   const [is3DMode, setIs3DMode] = useState(() => getViewMode());
-  
+
   // Terrain toggle state - default to plain mode for better dot visibility
   const [showTerrain, setShowTerrain] = useState(false);
-  
+
   // Simplified viewState management - single state for both modes
-  const { viewState, onViewStateChange, isZooming, isPanning } = useGlobeViewState();
-  
+  const { viewState, onViewStateChange, isZooming, isPanning } =
+    useGlobeViewState();
+
   // Population tooltip state
   const [tooltipData, setTooltipData] = useState<{
     population: number;
@@ -41,14 +54,11 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     settlementType?: string;
     clickPosition: { x: number; y: number };
   } | null>(null);
-  
-  
+
   // Save view mode preference to cookie
   useEffect(() => {
     setViewMode(is3DMode);
   }, [is3DMode]);
-  
-  
 
   // Removed complex viewport bounds system - tiles handle spatial filtering efficiently
 
@@ -57,80 +67,47 @@ function FootstepsViz({ year }: FootstepsVizProps) {
   const [featureCount, setFeatureCount] = useState<number>(0);
   const [totalPopulation, setTotalPopulation] = useState<number>(0);
 
-  // Year crossfade state
-  const [prevYear, setPrevYear] = useState<number | null>(null);
-  const [isYearCrossfading, setIsYearCrossfading] = useState<boolean>(false);
-  const [currentYearOpacity, setCurrentYearOpacity] = useState<number>(1);
-  const [prevYearOpacity, setPrevYearOpacity] = useState<number>(0);
-  const prevPropYearRef = useRef<number>(year);
-  const yearFadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const newLayerReadyRef = useRef<boolean>(false);
-  const newLayerHasTileRef = useRef<boolean>(false);
-  const YEAR_FADE_MS = 300;
-  const NEW_YEAR_FADE_MS = 120; // brief fade-in for perceptibility
+  const {
+    prevYear: renderPrevYear,
+    currentYearOpacity: renderCurrentOpacity,
+    prevYearOpacity: renderPrevOpacity,
+    isYearCrossfading,
+    newLayerReadyRef,
+    newLayerHasTileRef,
+    startCrossfade,
+  } = useYearCrossfade(year);
 
-
+  // Reset metrics when year changes
   useEffect(() => {
-    // If the year changed, set up a crossfade from the previous year to the new year.
-    if (year !== prevPropYearRef.current) {
-      const oldYear = prevPropYearRef.current;
-      prevPropYearRef.current = year;
-
-      // Prepare crossfade: show previous year at full opacity, new year at 0 until ready
-      setPrevYear(oldYear);
-      setIsYearCrossfading(true);
-      setPrevYearOpacity(1);
-      setCurrentYearOpacity(0);
-      newLayerReadyRef.current = false;
-      newLayerHasTileRef.current = false;
-
-      // Reset loading/metrics
-      setTileLoading(true);
-      setFeatureCount(0);
-      setTotalPopulation(0);
-
-      // Clear any pending cleanup
-      if (yearFadeTimeoutRef.current) {
-        clearTimeout(yearFadeTimeoutRef.current);
-        yearFadeTimeoutRef.current = null;
-      }
-      return;
-    }
-
-    // Initial mount or non-year updates: keep loading state consistent
     setTileLoading(true);
     setFeatureCount(0);
     setTotalPopulation(0);
   }, [year]);
-  
-  // Pre-render guard: if the year just changed on this render,
-  // keep the previous year visible and hide the new year until tiles arrive.
-  // This prevents a blank frame where the new-year layer (opacity 1) has no tiles yet
-  // and the previous-year layer has not been added by the effect.
-  const yearChangedThisRender = year !== prevPropYearRef.current;
-  const renderPrevYear = yearChangedThisRender ? prevPropYearRef.current : prevYear;
-  const renderCurrentOpacity = yearChangedThisRender ? 0 : currentYearOpacity;
-  const renderPrevOpacity = yearChangedThisRender ? 1 : prevYearOpacity;
 
   // Background layers - terrain or plain based on toggle
   const backgroundLayers = useMemo(() => {
-    return showTerrain ? [createStaticTerrainLayer()] : createPlainBackgroundLayers();
+    return showTerrain
+      ? [createStaticTerrainLayer()]
+      : createPlainBackgroundLayers();
   }, [showTerrain]);
-  
-  
+
   // Stable LOD level for memoization - only changes at discrete boundaries
   const roundedZoom = Math.floor(viewState.zoom);
   const stableLODLevel = useMemo(() => {
     return getLODLevel(roundedZoom);
   }, [roundedZoom]);
-  
+
   // Simplified: use viewState directly since LOD system provides stability
   const layerViewState = viewState;
-  
+
   // Hoisted helper so it's available to callbacks declared below
-  function featuresFromTile(tile: any): Array<{ properties?: { population?: number } }> {
+  function featuresFromTile(
+    tile: any,
+  ): Array<{ properties?: { population?: number } }> {
     try {
-      const tileCoords = tile?.index ? `${tile.index.z}/${tile.index.x}/${tile.index.y}` : 'unknown';
+      const tileCoords = tile?.index
+        ? `${tile.index.z}/${tile.index.x}/${tile.index.y}`
+        : 'unknown';
       void tileCoords; // quiet unused in production
       const possibleFeatures = [
         tile?.data?.features,
@@ -156,142 +133,185 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     }
   }
 
-  const createHumanLayerForYear = useCallback((targetYear: number, lodLevel: number, layerOpacity: number, instanceId: string, isNewYearLayer: boolean) => {
-    const radiusStrategy = is3DMode ? radiusStrategies.globe3D : radiusStrategies.zoomAdaptive;
+  const createHumanLayerForYear = useCallback(
+    (
+      targetYear: number,
+      lodLevel: number,
+      layerOpacity: number,
+      instanceId: string,
+      isNewYearLayer: boolean,
+    ) => {
+      const radiusStrategy = is3DMode
+        ? radiusStrategies.globe3D
+        : radiusStrategies.zoomAdaptive;
 
-    // Crossfade policy:
-    // - Before new tiles are ready: no transitions (avoid enter fade on prev layer)
-    // - When crossfade starts: NEW fades in briefly (NEW_YEAR_FADE_MS) for visibility,
-    //   PREV fades out (YEAR_FADE_MS)
-    const fadeMs = newLayerReadyRef.current
-      ? (isNewYearLayer ? NEW_YEAR_FADE_MS : YEAR_FADE_MS)
-      : 0;
+      // Crossfade policy:
+      // - Before new tiles are ready: no transitions (avoid enter fade on prev layer)
+      // - When crossfade starts: NEW fades in briefly (NEW_YEAR_FADE_MS) for visibility,
+      //   PREV fades out (YEAR_FADE_MS)
+      const fadeMs = newLayerReadyRef.current
+        ? isNewYearLayer
+          ? NEW_YEAR_FADE_MS
+          : YEAR_FADE_MS
+        : 0;
 
-    return createHumanTilesLayer(
-      targetYear,
-      lodLevel,
-      layerViewState,
-      radiusStrategy,
-      // onClick
-      (raw: unknown) => {
-        const info = raw as PickingInfo;
-        if (info?.object) {
-          const f = info.object as any;
-          const population = f?.properties?.population || 0;
-          const coordinates = (f?.geometry?.coordinates as [number, number]) || [0, 0];
-          const clickPosition = { x: info.x || 0, y: info.y || 0 };
-          setTooltipData({ population, coordinates, year: targetYear, clickPosition });
-        }
-      },
-      // onHover
-      (raw: unknown) => {
-        const info = raw as PickingInfo;
-        if (info?.object) {
-          const f = info.object as any;
-          const population = f?.properties?.population || 0;
-          const coordinates = (f?.geometry?.coordinates as [number, number]) || [0, 0];
-          const clickPosition = { x: info.x || 0, y: info.y || 0 };
-          setTooltipData({ population, coordinates, year: targetYear, clickPosition });
-        } else {
-          setTooltipData(null);
-        }
-      },
-      {
-        onTileLoad: (_tile: unknown) => {
-          // Only consider tile readiness/loading state from the NEW year layer.
-          // Do NOT start crossfade here; wait for onViewportLoad to ensure full coverage.
-          if (isNewYearLayer) {
-            setTileLoading(false);
-            if (!newLayerHasTileRef.current) {
-              newLayerHasTileRef.current = true;
-            }
+      return createHumanTilesLayer(
+        targetYear,
+        lodLevel,
+        layerViewState,
+        radiusStrategy,
+        // onClick
+        (raw: unknown) => {
+          const info = raw as PickingInfo;
+          if (info?.object) {
+            const f = info.object as any;
+            const population = f?.properties?.population || 0;
+            const coordinates = (f?.geometry?.coordinates as [
+              number,
+              number,
+            ]) || [0, 0];
+            const clickPosition = { x: info.x || 0, y: info.y || 0 };
+            setTooltipData({
+              population,
+              coordinates,
+              year: targetYear,
+              clickPosition,
+            });
           }
         },
-        onViewportLoad: (rawTiles: unknown[]) => {
-          try {
-            // Update metrics from the new (target) year layer when it reports tiles
+        // onHover
+        (raw: unknown) => {
+          const info = raw as PickingInfo;
+          if (info?.object) {
+            const f = info.object as any;
+            const population = f?.properties?.population || 0;
+            const coordinates = (f?.geometry?.coordinates as [
+              number,
+              number,
+            ]) || [0, 0];
+            const clickPosition = { x: info.x || 0, y: info.y || 0 };
+            setTooltipData({
+              population,
+              coordinates,
+              year: targetYear,
+              clickPosition,
+            });
+          } else {
+            setTooltipData(null);
+          }
+        },
+        {
+          onTileLoad: (_tile: unknown) => {
+            // Only consider tile readiness/loading state from the NEW year layer.
+            // Do NOT start crossfade here; wait for onViewportLoad to ensure full coverage.
             if (isNewYearLayer) {
-              const tiles = rawTiles as Array<unknown>;
-              let count = 0;
-              let pop = 0;
-              for (const t of tiles) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const tile = t as any;
-                const feats = featuresFromTile(tile);
-                count += feats.length;
-                for (const g of feats) pop += Number(g?.properties?.population) || 0;
-              }
-              setFeatureCount(count);
-              setTotalPopulation(pop);
               setTileLoading(false);
-
-              // Start crossfade once new layer has some tiles
-              // Guard against race where onViewportLoad fires before isYearCrossfading updates
-              if (!newLayerReadyRef.current && (isYearCrossfading || yearChangedThisRender)) {
-                newLayerReadyRef.current = true;
-                setCurrentYearOpacity(1);
-                setPrevYearOpacity(0);
-                // Remove previous layer after fade completes
-                yearFadeTimeoutRef.current = setTimeout(() => {
-                  setPrevYear(null);
-                  setIsYearCrossfading(false);
-                  yearFadeTimeoutRef.current = null;
-                }, YEAR_FADE_MS + 50);
+              if (!newLayerHasTileRef.current) {
+                newLayerHasTileRef.current = true;
               }
             }
-          } catch (error) {
-            console.error(`[VIEWPORT-LOAD-ERROR] Year: ${targetYear}, LOD: ${lodLevel}:`, error);
-            setTileLoading(false);
-          }
-        },
-        onTileError: (error: unknown) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const errorInfo = error as any;
-          const tileCoords = errorInfo?.tile?.index || errorInfo?.index || {};
-          const url = errorInfo?.tile?.url || errorInfo?.url || 'unknown';
-          const status = errorInfo?.response?.status || errorInfo?.status || 'unknown';
-          console.error(`[TILE-ERROR] Failed to load tile:`, {
-            year: targetYear,
-            lodLevel,
-            coords: `${tileCoords.z}/${tileCoords.x}/${tileCoords.y}`,
-            url,
-            status,
-            error: errorInfo?.message || errorInfo?.error || errorInfo
-          });
-          setTileLoading(false);
-        },
-        tileOptions: {
-          fadeMs: fadeMs, // drives opacity transitions per crossfade policy
-          debounceTime: (isZooming || isPanning) ? 80 : 20,
-          useBinary: false
-        },
-        // Dev-only tint to make crossfade layers visually distinct during debugging
-        debugTint: (process.env.NODE_ENV !== 'production' && isYearCrossfading)
-          ? (isNewYearLayer ? [0, 30, 80] : [80, 0, 0])
-          : undefined
-      },
-      layerOpacity,
-      instanceId,
-      is3DMode
-    );
-  }, [layerViewState, is3DMode, isZooming, isPanning, isYearCrossfading, yearChangedThisRender]);
+          },
+          onViewportLoad: (rawTiles: unknown[]) => {
+            try {
+              // Update metrics from the new (target) year layer when it reports tiles
+              if (isNewYearLayer) {
+                const tiles = rawTiles as Array<unknown>;
+                let count = 0;
+                let pop = 0;
+                for (const t of tiles) {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  const tile = t as any;
+                  const feats = featuresFromTile(tile);
+                  count += feats.length;
+                  for (const g of feats)
+                    pop += Number(g?.properties?.population) || 0;
+                }
+                setFeatureCount(count);
+                setTotalPopulation(pop);
+                setTileLoading(false);
 
-  // Fallback: if a tile arrived before crossfade flag turned true, start crossfade now.
-  useEffect(() => {
-    // Intentionally no-op: we defer crossfade until onViewportLoad confirms
-    // the new year's tiles in the current viewport are loaded. This avoids
-    // fading out the previous year too early and showing large missing squares.
-  }, [isYearCrossfading, year]);
+                // Start crossfade once new layer has some tiles
+                startCrossfade();
+              }
+            } catch (error) {
+              console.error(
+                `[VIEWPORT-LOAD-ERROR] Year: ${targetYear}, LOD: ${lodLevel}:`,
+                error,
+              );
+              setTileLoading(false);
+            }
+          },
+          onTileError: (error: unknown) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const errorInfo = error as any;
+            const tileCoords = errorInfo?.tile?.index || errorInfo?.index || {};
+            const url = errorInfo?.tile?.url || errorInfo?.url || 'unknown';
+            const status =
+              errorInfo?.response?.status || errorInfo?.status || 'unknown';
+            console.error(`[TILE-ERROR] Failed to load tile:`, {
+              year: targetYear,
+              lodLevel,
+              coords: `${tileCoords.z}/${tileCoords.x}/${tileCoords.y}`,
+              url,
+              status,
+              error: errorInfo?.message || errorInfo?.error || errorInfo,
+            });
+            setTileLoading(false);
+          },
+          tileOptions: {
+            fadeMs: fadeMs, // drives opacity transitions per crossfade policy
+            debounceTime: isZooming || isPanning ? 80 : 20,
+            useBinary: false,
+          },
+          // Dev-only tint to make crossfade layers visually distinct during debugging
+          debugTint:
+            process.env.NODE_ENV !== 'production' && isYearCrossfading
+              ? isNewYearLayer
+                ? [0, 30, 80]
+                : [80, 0, 0]
+              : undefined,
+        },
+        layerOpacity,
+        instanceId,
+        is3DMode,
+      );
+    },
+    [
+      layerViewState,
+      is3DMode,
+      isZooming,
+      isPanning,
+      isYearCrossfading,
+      newLayerHasTileRef,
+      newLayerReadyRef,
+      startCrossfade,
+    ],
+  );
 
   // Create human tiles layers for current and (if crossfading) previous year
-  const currentYearLayer = createHumanLayerForYear(year, stableLODLevel, renderCurrentOpacity, `human-layer-${year}`, true);
-  const previousYearLayer = renderPrevYear !== null ? createHumanLayerForYear(renderPrevYear as number, stableLODLevel, renderPrevOpacity, `human-layer-${renderPrevYear}`, false) : null;
-  
+  const currentYearLayer = createHumanLayerForYear(
+    year,
+    stableLODLevel,
+    renderCurrentOpacity,
+    `human-layer-${year}`,
+    true,
+  );
+  const previousYearLayer =
+    renderPrevYear !== null
+      ? createHumanLayerForYear(
+          renderPrevYear as number,
+          stableLODLevel,
+          renderPrevOpacity,
+          `human-layer-${renderPrevYear}`,
+          false,
+        )
+      : null;
+
   // Layer ordering: background layers -> settlement points
   const layers: LayersList = previousYearLayer
     ? ([...backgroundLayers, previousYearLayer, currentYearLayer] as LayersList)
     : ([...backgroundLayers, currentYearLayer] as LayersList);
-  
+
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const logLayer = (layer: any, tag: string, tagYear: number | null) => {
@@ -309,15 +329,16 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         fadeMs: opacityTransition?.duration,
         is3DMode,
         isYearCrossfading,
-        newLayerReady: newLayerReadyRef.current
+        newLayerReady: newLayerReadyRef.current,
       });
     };
     logLayer(currentYearLayer, 'current', year);
-    if (previousYearLayer) logLayer(previousYearLayer, 'previous', renderPrevYear as number);
+    if (previousYearLayer)
+      logLayer(previousYearLayer, 'previous', renderPrevYear as number);
   } catch {
     // ignore logging errors in dev
   }
-  
+
   return (
     <div className="relative w-full h-full">
       {is3DMode ? (
@@ -333,7 +354,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
           layers={layers}
         />
       )}
-      
+
       {/* Data info overlay */}
       <SupportingText
         loading={tileLoading}
@@ -343,14 +364,19 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         lodLevel={stableLODLevel}
         lodEnabled={false}
         toggleLOD={() => {}}
-        renderMetrics={{loadTime: 0, processTime: 0, renderTime: 0, lastUpdate: 0}}
+        renderMetrics={{
+          loadTime: 0,
+          processTime: 0,
+          renderTime: 0,
+          lastUpdate: 0,
+        }}
         cacheSize={1}
         progressiveRenderStatus={undefined}
         viewportBounds={null}
         is3DMode={is3DMode}
         year={year}
       />
-      
+
       {/* View Mode + Terrain toggles */}
       <div className="absolute top-4 right-4 z-10 flex flex-col gap-2">
         <VizToggles
@@ -363,9 +389,9 @@ function FootstepsViz({ year }: FootstepsVizProps) {
 
       {/* Legend */}
       <LegendOverlay />
-      
+
       {/* Population Tooltip */}
-      <PopulationTooltip 
+      <PopulationTooltip
         data={tooltipData}
         onClose={() => setTooltipData(null)}
       />

--- a/humans-globe/components/footsteps/hooks/useYearCrossfade.test.ts
+++ b/humans-globe/components/footsteps/hooks/useYearCrossfade.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react';
+import useYearCrossfade, {
+  YEAR_FADE_MS,
+} from '@/components/footsteps/hooks/useYearCrossfade';
+
+describe('useYearCrossfade', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('crossfades between years with expected timing', () => {
+    const { result, rerender } = renderHook(
+      ({ year }: { year: number }) => useYearCrossfade(year),
+      {
+        initialProps: { year: 1000 },
+      },
+    );
+
+    expect(result.current.prevYear).toBeNull();
+    expect(result.current.currentYearOpacity).toBe(1);
+    expect(result.current.prevYearOpacity).toBe(0);
+    expect(result.current.isYearCrossfading).toBe(false);
+
+    act(() => {
+      rerender({ year: 1500 });
+    });
+
+    expect(result.current.prevYear).toBe(1000);
+    expect(result.current.currentYearOpacity).toBe(0);
+    expect(result.current.prevYearOpacity).toBe(1);
+    expect(result.current.isYearCrossfading).toBe(true);
+
+    act(() => {
+      result.current.startCrossfade();
+    });
+
+    expect(result.current.prevYear).toBe(1000);
+    expect(result.current.currentYearOpacity).toBe(1);
+    expect(result.current.prevYearOpacity).toBe(0);
+    expect(result.current.isYearCrossfading).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(YEAR_FADE_MS + 60);
+    });
+
+    expect(result.current.prevYear).toBeNull();
+    expect(result.current.isYearCrossfading).toBe(false);
+  });
+});

--- a/humans-globe/components/footsteps/hooks/useYearCrossfade.ts
+++ b/humans-globe/components/footsteps/hooks/useYearCrossfade.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+export const YEAR_FADE_MS = 300;
+export const NEW_YEAR_FADE_MS = 120;
+
+export default function useYearCrossfade(year: number) {
+  const [prevYear, setPrevYear] = useState<number | null>(null);
+  const [isYearCrossfading, setIsYearCrossfading] = useState(false);
+  const [currentYearOpacity, setCurrentYearOpacity] = useState(1);
+  const [prevYearOpacity, setPrevYearOpacity] = useState(0);
+
+  const prevPropYearRef = useRef<number>(year);
+  const yearFadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const newLayerReadyRef = useRef(false);
+  const newLayerHasTileRef = useRef(false);
+
+  useEffect(() => {
+    if (year !== prevPropYearRef.current) {
+      const oldYear = prevPropYearRef.current;
+      prevPropYearRef.current = year;
+      setPrevYear(oldYear);
+      setIsYearCrossfading(true);
+      setPrevYearOpacity(1);
+      setCurrentYearOpacity(0);
+      newLayerReadyRef.current = false;
+      newLayerHasTileRef.current = false;
+      if (yearFadeTimeoutRef.current) {
+        clearTimeout(yearFadeTimeoutRef.current);
+        yearFadeTimeoutRef.current = null;
+      }
+    }
+  }, [year]);
+
+  useEffect(() => {
+    return () => {
+      if (yearFadeTimeoutRef.current) {
+        clearTimeout(yearFadeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const startCrossfade = () => {
+    if (newLayerReadyRef.current || prevYear === null) {
+      return;
+    }
+    newLayerReadyRef.current = true;
+    setCurrentYearOpacity(1);
+    setPrevYearOpacity(0);
+    yearFadeTimeoutRef.current = setTimeout(() => {
+      setPrevYear(null);
+      setIsYearCrossfading(false);
+      yearFadeTimeoutRef.current = null;
+    }, YEAR_FADE_MS + 50);
+  };
+
+  const yearChangedThisRender = year !== prevPropYearRef.current;
+  const renderPrevYear = yearChangedThisRender
+    ? prevPropYearRef.current
+    : prevYear;
+  const renderCurrentOpacity = yearChangedThisRender ? 0 : currentYearOpacity;
+  const renderPrevOpacity = yearChangedThisRender ? 1 : prevYearOpacity;
+
+  return {
+    prevYear: renderPrevYear,
+    currentYearOpacity: renderCurrentOpacity,
+    prevYearOpacity: renderPrevOpacity,
+    isYearCrossfading,
+    newLayerReadyRef,
+    newLayerHasTileRef,
+    startCrossfade,
+    YEAR_FADE_MS,
+    NEW_YEAR_FADE_MS,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useYearCrossfade` hook for managing crossfade state and timing
- integrate crossfade hook into `FootstepsViz` to simplify year transitions
- test crossfade behavior to preserve fade timing

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a44415eb808323a0885d5b5ce4d36b