### PR TITLE
refactor: centralize SupportingText formatting helpers

### DIFF
--- a/humans-globe/components/footsteps/overlays/SupportingText.tsx
+++ b/humans-globe/components/footsteps/overlays/SupportingText.tsx
@@ -1,6 +1,7 @@
-"use client";
+'use client';
 
 import React from 'react';
+import { formatPopulation, getDetailContext, formatYear } from '@/lib/format';
 
 interface RenderMetrics {
   loadTime: number;
@@ -25,48 +26,36 @@ interface Props {
   year: number; // Current year being rendered
 }
 
-export default function SupportingText({
+function SupportingText({
   loading = false,
   dotCount,
   totalPopulation,
   viewState,
   lodLevel,
-  // lodEnabled and toggleLOD intentionally not destructured to avoid unused vars
-  renderMetrics,
-  cacheSize,
   progressiveRenderStatus,
-  viewportBounds,
-  is3DMode,
-  year
+  year,
+  // Additional props intentionally omitted to avoid unused var warnings
 }: Props) {
   if (loading) {
     return (
       <div
         className="absolute backdrop-blur-md bg-black/50 rounded-lg p-4 text-slate-200 font-sans flex items-center justify-center"
-        style={{ top: '5rem', left: '2rem', zIndex: 30, minWidth: '200px', minHeight: '120px' }}
+        style={{
+          top: '5rem',
+          left: '2rem',
+          zIndex: 30,
+          minWidth: '200px',
+          minHeight: '120px',
+        }}
       >
-        <span className="animate-pulse text-sm text-slate-300">Loading human presence data…</span>
+        <span className="animate-pulse text-sm text-slate-300">
+          Loading human presence data…
+        </span>
       </div>
     );
   }
 
   const isDevelopment = process.env.NODE_ENV === 'development';
-
-  const formatPopulation = (pop: number): string => {
-    if (pop >= 1_000_000_000) return `${Math.round(pop / 1_000_000_000).toLocaleString()}B people`;
-    if (pop >= 1_000_000) return `${Math.round(pop / 1_000_000).toLocaleString()}M people`;
-    if (pop >= 1_000) return `${Math.round(pop / 1_000).toLocaleString()}K people`;
-    return `${Math.round(pop).toLocaleString()} people`;
-  };
-
-  const getDetailContext = (zoom: number): string => {
-    if (zoom < 4) return 'Regional clusters • Showing major population centers';
-    if (zoom < 5) return 'Subregional detail • Country & province scale';
-    if (zoom < 6) return 'Local communities • County & district scale';
-    return 'Detailed settlements • Full resolution data';
-  };
-
-  const formatYear = (y: number): string => (y < 0 ? `${Math.abs(y)} BC` : `${y} CE`);
 
   return (
     <div
@@ -78,24 +67,37 @@ export default function SupportingText({
 
       {/* Title and primary metric */}
       <div className="text-sm mb-1">Human presence</div>
-      <div className="text-xl font-semibold mb-2">{formatPopulation(totalPopulation)}</div>
+      <div className="text-xl font-semibold mb-2">
+        {formatPopulation(totalPopulation)}
+      </div>
 
       {/* Current view context */}
-      <div className="text-xs text-slate-400 mb-1">{getDetailContext(viewState.zoom)}</div>
+      <div className="text-xs text-slate-400 mb-1">
+        {getDetailContext(viewState.zoom)}
+      </div>
 
       {/* Progressive loading feedback */}
-      {progressiveRenderStatus && progressiveRenderStatus.rendered < progressiveRenderStatus.total && (
-        <div className="text-xs text-slate-300 mt-2">
-          Loading settlements: {((progressiveRenderStatus.rendered / progressiveRenderStatus.total) * 100).toFixed(0)}%
-        </div>
-      )}
+      {progressiveRenderStatus &&
+        progressiveRenderStatus.rendered < progressiveRenderStatus.total && (
+          <div className="text-xs text-slate-300 mt-2">
+            Loading settlements:{' '}
+            {(
+              (progressiveRenderStatus.rendered /
+                progressiveRenderStatus.total) *
+              100
+            ).toFixed(0)}
+            %
+          </div>
+        )}
 
       {/* Development debugging */}
       {isDevelopment && (
         <details open className="mt-3 text-xs text-slate-500">
           <summary className="cursor-pointer">Debug</summary>
           <div className="mt-2 pt-2 border-t border-slate-700/60 space-y-1">
-            <div>Zoom: {viewState.zoom.toFixed(1)}x • LOD: {lodLevel}</div>
+            <div>
+              Zoom: {viewState.zoom.toFixed(1)}x • LOD: {lodLevel}
+            </div>
             <div>Dots drawn: {dotCount.toLocaleString()}</div>
           </div>
         </details>
@@ -103,3 +105,5 @@ export default function SupportingText({
     </div>
   );
 }
+
+export default React.memo(SupportingText);

--- a/humans-globe/lib/format.ts
+++ b/humans-globe/lib/format.ts
@@ -1,0 +1,31 @@
+// Shared formatting utilities for the Humans Globe frontend
+
+// Format population counts into human‑readable strings
+export function formatPopulation(pop: number): string {
+  if (pop >= 1_000_000_000)
+    return `${Math.round(pop / 1_000_000_000).toLocaleString()}B people`;
+  if (pop >= 1_000_000)
+    return `${Math.round(pop / 1_000_000).toLocaleString()}M people`;
+  if (pop >= 1_000)
+    return `${Math.round(pop / 1_000).toLocaleString()}K people`;
+  return `${Math.round(pop).toLocaleString()} people`;
+}
+
+// Describe the level of detail based on zoom level
+export function getDetailContext(zoom: number): string {
+  if (zoom < 4) return 'Regional clusters • Showing major population centers';
+  if (zoom < 5) return 'Subregional detail • Country & province scale';
+  if (zoom < 6) return 'Local communities • County & district scale';
+  return 'Detailed settlements • Full resolution data';
+}
+
+// Format historical years for display
+export function formatYear(year: number): string {
+  if (year < 0) {
+    return `${Math.abs(year)} BC`;
+  }
+  if (year === 0) {
+    return '1 CE';
+  }
+  return `${year} CE`;
+}


### PR DESCRIPTION
## Summary
- extract population, detail, and year formatting helpers into `lib/format.ts`
- import shared helpers in `SupportingText` and memoize component to avoid unnecessary re-renders
- re-export `formatYear` from `useYear` for wider reuse

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run isort footstep-generator --check` (fails: imports not sorted)
- `poetry run black footstep-generator --check` (fails: files would be reformatted)
- `poetry run pytest footstep-generator -q` (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_68a4444e3c908323992001ecf272abb2