### PR TITLE
feat: extract tooltip utilities

### DIFF
--- a/humans-globe/components/footsteps/overlays/PopulationTooltip.tsx
+++ b/humans-globe/components/footsteps/overlays/PopulationTooltip.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
+import {
+  getTooltipPosition,
+  getPopulationScale,
+  formatCoordinates,
+} from './tooltipUtils';
 
 interface TooltipData {
   population: number;
@@ -19,7 +24,10 @@ interface PopulationTooltipProps {
  * Minimalist tooltip for displaying population data when clicking on dots.
  * Follows the established design philosophy of data-driven minimalism.
  */
-export default function PopulationTooltip({ data, onClose }: PopulationTooltipProps) {
+export default function PopulationTooltip({
+  data,
+  onClose,
+}: PopulationTooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
 
   const handleClose = useCallback(() => {
@@ -57,65 +65,9 @@ export default function PopulationTooltip({ data, onClose }: PopulationTooltipPr
 
   if (!data) return null;
 
-  // Calculate tooltip position with boundary detection
-  const getTooltipPosition = () => {
-    const tooltipWidth = 260;
-    const tooltipHeight = 100;
-    const padding = 16;
-    
-    let left = data.clickPosition.x + 16; // Offset from cursor
-    let top = data.clickPosition.y - tooltipHeight - 16; // Above cursor
-
-    // Boundary detection
-    if (typeof window !== 'undefined') {
-      // Right boundary
-      if (left + tooltipWidth > window.innerWidth - padding) {
-        left = data.clickPosition.x - tooltipWidth - 16; // Show on left
-      }
-      
-      // Top boundary
-      if (top < padding) {
-        top = data.clickPosition.y + 16; // Show below cursor
-      }
-      
-      // Bottom boundary
-      if (top + tooltipHeight > window.innerHeight - padding) {
-        top = window.innerHeight - tooltipHeight - padding;
-      }
-      
-      // Left boundary
-      if (left < padding) {
-        left = padding;
-      }
-    }
-
-    return { left, top };
-  };
-
-  
-
-  // Get population scale with more nuanced categories
-  const getPopulationScale = (population: number): { scale: string; icon: string; significance: string } => {
-    if (population > 1000000) return { scale: 'Megacity', icon: '🏙️', significance: 'Major urban center' };
-    if (population > 500000) return { scale: 'Metropolis', icon: '🌆', significance: 'Large city' };
-    if (population > 100000) return { scale: 'City', icon: '🏘️', significance: 'Urban settlement' };
-    if (population > 50000) return { scale: 'Large Town', icon: '🏘️', significance: 'Regional center' };
-    if (population > 10000) return { scale: 'Town', icon: '🏘️', significance: 'Local hub' };
-    if (population > 2000) return { scale: 'Village', icon: '🏠', significance: 'Rural community' };
-    if (population > 500) return { scale: 'Hamlet', icon: '🏡', significance: 'Small settlement' };
-    return { scale: 'Outpost', icon: '⛺', significance: 'Remote presence' };
-  };
-
-  // Format coordinates
-  const formatCoordinates = (coords: [number, number]): string => {
-    const [lon, lat] = coords;
-    const latDir = lat >= 0 ? 'N' : 'S';
-    const lonDir = lon >= 0 ? 'E' : 'W';
-    return `${Math.abs(lat).toFixed(2)}°${latDir}, ${Math.abs(lon).toFixed(2)}°${lonDir}`;
-  };
-
-  const position = getTooltipPosition();
+  const position = getTooltipPosition(data.clickPosition);
   const populationScale = getPopulationScale(data.population);
+
   const roundedPopulation = Math.round(data.population);
   const populationLabel = roundedPopulation === 1 ? 'person' : 'people';
 
@@ -130,42 +82,46 @@ export default function PopulationTooltip({ data, onClose }: PopulationTooltipPr
           left: `${position.left}px`,
           top: `${position.top}px`,
           minWidth: '220px',
-          maxWidth: '260px'
+          maxWidth: '260px',
         }}
       >
         <div className="pointer-events-auto bg-slate-900/95 backdrop-blur-sm rounded-md p-3 pr-4 text-white shadow-xl border border-slate-700/40">
-        {/* Population (primary) */}
-        <div className="mb-2">
-          <div className="text-3xl font-semibold text-orange-300 leading-none tracking-tight">
-            <span className="font-mono">{roundedPopulation.toLocaleString()}</span>{' '}
-            <span className="text-base font-normal text-slate-300">{populationLabel}</span>
-          </div>
-        </div>
-
-        {/* Subheader: Year + Scale badge + Close */}
-        <div className="flex items-center justify-between mb-2 gap-2">
-          <div className="text-xs text-slate-400 truncate">
-            {data.year < 0 ? `${Math.abs(data.year)} BC` : `${data.year} CE`}
-          </div>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <div className="text-[10px] px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800 text-slate-300">
-              {populationScale.scale}
+          {/* Population (primary) */}
+          <div className="mb-2">
+            <div className="text-3xl font-semibold text-orange-300 leading-none tracking-tight">
+              <span className="font-mono">
+                {roundedPopulation.toLocaleString()}
+              </span>{' '}
+              <span className="text-base font-normal text-slate-300">
+                {populationLabel}
+              </span>
             </div>
-            <button
-              onClick={handleClose}
-              className="text-slate-400 hover:text-white hover:bg-slate-700/50 transition-all duration-200 text-base leading-none w-6 h-6 flex items-center justify-center rounded"
-              title="Close (ESC)"
-              aria-label="Close tooltip"
-            >
-              ×
-            </button>
           </div>
-        </div>
 
-        {/* Coordinates */}
-        <div className="text-[11px] text-slate-400">
-          {formatCoordinates(data.coordinates)}
-        </div>
+          {/* Subheader: Year + Scale badge + Close */}
+          <div className="flex items-center justify-between mb-2 gap-2">
+            <div className="text-xs text-slate-400 truncate">
+              {data.year < 0 ? `${Math.abs(data.year)} BC` : `${data.year} CE`}
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <div className="text-[10px] px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800 text-slate-300">
+                {populationScale.scale}
+              </div>
+              <button
+                onClick={handleClose}
+                className="text-slate-400 hover:text-white hover:bg-slate-700/50 transition-all duration-200 text-base leading-none w-6 h-6 flex items-center justify-center rounded"
+                title="Close (ESC)"
+                aria-label="Close tooltip"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+
+          {/* Coordinates */}
+          <div className="text-[11px] text-slate-400">
+            {formatCoordinates(data.coordinates)}
+          </div>
         </div>
       </div>
     </>

--- a/humans-globe/components/footsteps/overlays/tooltipUtils.test.ts
+++ b/humans-globe/components/footsteps/overlays/tooltipUtils.test.ts
@@ -1,0 +1,58 @@
+import {
+  getTooltipPosition,
+  getPopulationScale,
+  formatCoordinates,
+} from './tooltipUtils';
+
+describe('getTooltipPosition', () => {
+  it('positions tooltip to the left when near the right edge', () => {
+    const pos = getTooltipPosition(
+      { x: 390, y: 150 },
+      { innerWidth: 400, innerHeight: 300 },
+    );
+    expect(pos.left).toBe(390 - 260 - 16);
+  });
+
+  it('positions tooltip below the cursor when near the top edge', () => {
+    const pos = getTooltipPosition(
+      { x: 200, y: 20 },
+      { innerWidth: 400, innerHeight: 300 },
+    );
+    expect(pos.top).toBe(20 + 16);
+  });
+
+  it('clamps tooltip within viewport on small screens', () => {
+    const pos = getTooltipPosition(
+      { x: 190, y: 110 },
+      { innerWidth: 200, innerHeight: 120 },
+    );
+    expect(pos.left).toBe(16);
+    expect(pos.top).toBe(120 - 100 - 16);
+  });
+});
+
+describe('getPopulationScale', () => {
+  it('returns correct scale labels for population thresholds', () => {
+    const cases = [
+      [1500000, 'Megacity'],
+      [600000, 'Metropolis'],
+      [150000, 'City'],
+      [60000, 'Large Town'],
+      [20000, 'Town'],
+      [5000, 'Village'],
+      [1000, 'Hamlet'],
+      [100, 'Outpost'],
+    ] as const;
+
+    cases.forEach(([pop, label]) => {
+      expect(getPopulationScale(pop).scale).toBe(label);
+    });
+  });
+});
+
+describe('formatCoordinates', () => {
+  it('formats latitude and longitude with cardinal directions', () => {
+    expect(formatCoordinates([30.1234, -25.5678])).toBe('25.57°S, 30.12°E');
+    expect(formatCoordinates([-45.6789, 20.1234])).toBe('20.12°N, 45.68°W');
+  });
+});

--- a/humans-globe/components/footsteps/overlays/tooltipUtils.ts
+++ b/humans-globe/components/footsteps/overlays/tooltipUtils.ts
@@ -1,0 +1,78 @@
+export function getTooltipPosition(
+  clickPosition: { x: number; y: number },
+  windowSize?: { innerWidth: number; innerHeight: number },
+): { left: number; top: number } {
+  const tooltipWidth = 260;
+  const tooltipHeight = 100;
+  const padding = 16;
+
+  let left = clickPosition.x + 16; // Offset from cursor
+  let top = clickPosition.y - tooltipHeight - 16; // Above cursor
+
+  const winWidth =
+    windowSize?.innerWidth ??
+    (typeof window !== 'undefined' ? window.innerWidth : undefined);
+  const winHeight =
+    windowSize?.innerHeight ??
+    (typeof window !== 'undefined' ? window.innerHeight : undefined);
+
+  if (winWidth !== undefined && winHeight !== undefined) {
+    if (left + tooltipWidth > winWidth - padding) {
+      left = clickPosition.x - tooltipWidth - 16; // Show on left
+    }
+
+    if (top < padding) {
+      top = clickPosition.y + 16; // Show below cursor
+    }
+
+    if (top + tooltipHeight > winHeight - padding) {
+      top = winHeight - tooltipHeight - padding;
+    }
+
+    if (left < padding) {
+      left = padding;
+    }
+  }
+
+  return { left, top };
+}
+
+export function getPopulationScale(population: number): {
+  scale: string;
+  icon: string;
+  significance: string;
+} {
+  if (population > 1000000) {
+    return {
+      scale: 'Megacity',
+      icon: '🏙️',
+      significance: 'Major urban center',
+    };
+  }
+  if (population > 500000) {
+    return { scale: 'Metropolis', icon: '🌆', significance: 'Large city' };
+  }
+  if (population > 100000) {
+    return { scale: 'City', icon: '🏘️', significance: 'Urban settlement' };
+  }
+  if (population > 50000) {
+    return { scale: 'Large Town', icon: '🏘️', significance: 'Regional center' };
+  }
+  if (population > 10000) {
+    return { scale: 'Town', icon: '🏘️', significance: 'Local hub' };
+  }
+  if (population > 2000) {
+    return { scale: 'Village', icon: '🏠', significance: 'Rural community' };
+  }
+  if (population > 500) {
+    return { scale: 'Hamlet', icon: '🏡', significance: 'Small settlement' };
+  }
+  return { scale: 'Outpost', icon: '⛺', significance: 'Remote presence' };
+}
+
+export function formatCoordinates(coords: [number, number]): string {
+  const [lon, lat] = coords;
+  const latDir = lat >= 0 ? 'N' : 'S';
+  const lonDir = lon >= 0 ? 'E' : 'W';
+  return `${Math.abs(lat).toFixed(2)}°${latDir}, ${Math.abs(lon).toFixed(2)}°${lonDir}`;
+}


### PR DESCRIPTION
## Summary
- factor out tooltip helpers into `tooltipUtils.ts`
- use shared helpers in `PopulationTooltip`
- add unit tests for tooltip positioning, population scaling, and coordinate formatting

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45d3a86208323b128b9981de7d7e6