### PR TITLE
refactor: centralize year scaling config

### DIFF
--- a/humans-globe/lib/useYear.test.ts
+++ b/humans-globe/lib/useYear.test.ts
@@ -26,6 +26,11 @@ describe('yearToSlider and sliderToYear', () => {
       expect(sliderToYear(pos)).toBe(year);
     }
   });
+
+  it('round trips non-target years to nearest target year', () => {
+    expect(sliderToYear(yearToSlider(1066))).toBe(1100);
+    expect(sliderToYear(yearToSlider(-9500))).toBe(-10000);
+  });
 });
 
 describe('formatYear', () => {

--- a/humans-globe/lib/useYear.ts
+++ b/humans-globe/lib/useYear.ts
@@ -3,68 +3,75 @@
 import { useState, useCallback } from 'react';
 import { TARGET_YEARS } from './constants';
 
-// Data range constants (based on our available HYDE 3.3 data)
-const MIN_YEAR = TARGET_YEARS[0]; // -10000 BCE
-const MAX_YEAR = TARGET_YEARS[TARGET_YEARS.length - 1]; // 1500 CE
+export interface YearScaleConfig {
+  minYear: number;
+  maxYear: number;
+  compressionFactor: number;
+}
 
-// Time scale compression factor - ADJUST THIS VALUE TO CHANGE TIME SCALING
-// Lower values (10-100) = more expansion of recent years
-// Higher values (500-2000) = less expansion of recent years
-// Current: 200 gives balanced scaling for deep history (10k BCE to 1500 CE)
-// Compression factor controls how much recent years are compressed.
-// Increase this value to make 1400-1500 take less space; decrease to expand them.
-const COMPRESSION_FACTOR = 800;
+export const YEAR_SCALE_CONFIG: YearScaleConfig = {
+  minYear: TARGET_YEARS[0], // -10000 BCE
+  maxYear: TARGET_YEARS[TARGET_YEARS.length - 1], // 1500 CE
+  // Time scale compression factor - ADJUST THIS VALUE TO CHANGE TIME SCALING
+  // Lower values (10-100) = more expansion of recent years
+  // Higher values (500-2000) = less expansion of recent years
+  // Compression factor controls how much recent years are compressed.
+  // Increase this value to make 1400-1500 take less space; decrease to expand them.
+  compressionFactor: 800,
+};
 
 // Natural logarithmic scale based on years ago (recent dates naturally expanded)
-function getScaledPosition(year: number): number {
-  const minYear = MIN_YEAR; // -10000
-  const maxYear = MAX_YEAR; // 1940
-  
+function getScaledPosition(
+  year: number,
+  { minYear, maxYear, compressionFactor }: YearScaleConfig,
+): number {
   // Calculate "years ago" from the most recent year (1500)
   // More recent years have smaller "years ago" values
   const yearsAgo = maxYear - year;
   const maxYearsAgo = maxYear - minYear;
-  
-  const compressionFactor = COMPRESSION_FACTOR;
-  
+
   const logYearsAgo = Math.log(yearsAgo + compressionFactor);
   const logMaxYearsAgo = Math.log(maxYearsAgo + compressionFactor);
-  
+
   // Invert: recent years (small logYearsAgo) get high slider positions
-  const position = 1 - (logYearsAgo / logMaxYearsAgo);
-  
+  const position = 1 - logYearsAgo / logMaxYearsAgo;
+
   return position * 100;
 }
 
-
-
 // Convert year to slider position (0-100) using normalised logarithmic scale
 // Raw maximum position computed for MAX_YEAR (most recent)
-const RAW_MAX_POSITION = getScaledPosition(MAX_YEAR);
+const RAW_MAX_POSITION = getScaledPosition(
+  YEAR_SCALE_CONFIG.maxYear,
+  YEAR_SCALE_CONFIG,
+);
 
 // Convert year to slider position (0-100) normalised over raw max
 export function yearToSlider(year: number): number {
-  const raw = getScaledPosition(Math.min(Math.max(year, MIN_YEAR), MAX_YEAR));
+  const clamped = Math.min(
+    Math.max(year, YEAR_SCALE_CONFIG.minYear),
+    YEAR_SCALE_CONFIG.maxYear,
+  );
+  const raw = getScaledPosition(clamped, YEAR_SCALE_CONFIG);
   return (raw / RAW_MAX_POSITION) * 100;
 }
 
 // Reverse the natural logarithmic scaling to get year from slider position
-function getYearFromScaledPosition(position: number): number {
-  const minYear = MIN_YEAR;
-  const maxYear = MAX_YEAR;
+function getYearFromScaledPosition(
+  position: number,
+  { minYear, maxYear, compressionFactor }: YearScaleConfig,
+): number {
   const maxYearsAgo = maxYear - minYear;
 
-    const compressionFactor = COMPRESSION_FACTOR;
-  
   // position is 0-100 normalised; map back to raw 0-RAW_MAX_POSITION
-  const positionRatio = (position / 100);
+  const positionRatio = position / 100;
   const rawPos = positionRatio * RAW_MAX_POSITION;
   // Convert rawPos to same ratio for log calculation
   const logPositionRatio = rawPos / RAW_MAX_POSITION;
 
   const logMaxYearsAgo = Math.log(maxYearsAgo + compressionFactor);
   const logYearsAgo = (1 - logPositionRatio) * logMaxYearsAgo;
-    let yearsAgo = Math.exp(logYearsAgo) - compressionFactor;
+  let yearsAgo = Math.exp(logYearsAgo) - compressionFactor;
   if (yearsAgo < 0) yearsAgo = 0; // prevent overshoot beyond most recent year
   const year = maxYear - yearsAgo;
 
@@ -76,7 +83,7 @@ export function sliderToYear(position: number): number {
   const clamped = Math.min(Math.max(position, 0), 100);
   // Map slider 0-100 back to raw position
   const rawPos = (clamped / 100) * RAW_MAX_POSITION;
-  const theoreticalYear = getYearFromScaledPosition(rawPos);
+  const theoreticalYear = getYearFromScaledPosition(rawPos, YEAR_SCALE_CONFIG);
 
   // Snap to nearest target year
   let closestYear = TARGET_YEARS[0];
@@ -89,7 +96,7 @@ export function sliderToYear(position: number): number {
       closestYear = targetYear;
     }
   }
-    return closestYear;
+  return closestYear;
 }
 
 // Format year for display
@@ -108,23 +115,23 @@ export function formatYear(year: number): string {
 export function useYear(initialYear: number = 0) {
   const [year, setYear] = useState(initialYear);
   const [sliderValue, setSliderValue] = useState(yearToSlider(initialYear));
-  
+
   const updateYear = useCallback((newYear: number) => {
     setYear(newYear);
     setSliderValue(yearToSlider(newYear));
   }, []);
-  
+
   const updateSlider = useCallback((newSliderValue: number) => {
     const newYear = sliderToYear(newSliderValue);
     setSliderValue(newSliderValue);
     setYear(newYear);
   }, []);
-  
+
   return {
     year,
     sliderValue,
     updateYear,
     updateSlider,
-    formattedYear: formatYear(year)
+    formattedYear: formatYear(year),
   };
 }


### PR DESCRIPTION
## Summary
- centralize slider min/max years and compression factor in `YEAR_SCALE_CONFIG`
- refactor scaling helpers to accept config parameters
- test round-trip year conversions, including snapping of non-target years

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45d84f6d4832384ee0431c04fb636