### PR TITLE
refactor: extract byte length helper

### DIFF
--- a/humans-globe/components/footsteps/layers/humanLayer.ts
+++ b/humans-globe/components/footsteps/layers/humanLayer.ts
@@ -1,6 +1,7 @@
 import { MVTLayer } from '@deck.gl/geo-layers';
 import { getTileUrlPattern } from '@/lib/tilesConfig';
 import { radiusStrategies, type RadiusStrategy } from './radiusStrategies';
+import { ensureByteLength } from '@/lib/ensureByteLength';
 
 // Helper: map population to a base display radius in meters
 function getBaseRadiusFromPopulation(population: number): number {
@@ -103,43 +104,11 @@ export function createHumanTilesLayer(
     onHover: onHover || (() => {}),
     // Ensure deck.gl always receives callable callbacks to avoid TypeErrors
     onTileLoad: (tile: unknown) => {
+      const content = (tile as { content?: unknown })?.content;
       try {
-        // Attach an approximate byteLength so Tileset2D doesn't error
-        const t = tile as { content?: unknown };
-        const content = t && 'content' in t ? (t as any).content : undefined;
-        const hasFiniteByteLength =
-          typeof (content as any)?.byteLength === 'number' &&
-          Number.isFinite((content as any).byteLength);
-        if (content && !hasFiniteByteLength) {
-          let approx = 0;
-          try {
-            if (typeof content === 'string') {
-              approx = content.length;
-            } else if (
-              content instanceof ArrayBuffer ||
-              ArrayBuffer.isView(content)
-            ) {
-              // Covers ArrayBuffer and typed arrays
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              approx = (content as any).byteLength || 0;
-            } else {
-              // Fall back to JSON size estimate for GeoJSON-like objects
-              approx = JSON.stringify(content).length;
-            }
-          } catch {
-            // Ignore estimation errors; leave undefined
-          }
-          if (Number.isFinite(approx) && approx > 0) {
-            try {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (content as any).byteLength = approx;
-            } catch {
-              // If content is not extensible, ignore
-            }
-          }
-        }
+        ensureByteLength(content);
       } catch {
-        // Swallow any defensive errors here
+        /* ignore byteLength estimation errors */
       }
       if (typeof extra?.onTileLoad === 'function') extra.onTileLoad(tile);
     },

--- a/humans-globe/lib/ensureByteLength.test.ts
+++ b/humans-globe/lib/ensureByteLength.test.ts
@@ -1,0 +1,20 @@
+import { ensureByteLength } from './ensureByteLength';
+
+describe('ensureByteLength', () => {
+  it('estimates byte length for strings', () => {
+    expect(ensureByteLength('hello')).toBe(5);
+  });
+
+  it('returns existing byte length for ArrayBuffer', () => {
+    const buf = new Uint8Array([1, 2, 3]).buffer;
+    expect(ensureByteLength(buf)).toBe(3);
+  });
+
+  it('attaches byteLength for objects', () => {
+    const obj: Record<string, unknown> = { foo: 'bar' };
+    const expected = JSON.stringify(obj).length;
+    const result = ensureByteLength(obj);
+    expect(result).toBe(expected);
+    expect((obj as { byteLength?: number }).byteLength).toBe(expected);
+  });
+});

--- a/humans-globe/lib/ensureByteLength.ts
+++ b/humans-globe/lib/ensureByteLength.ts
@@ -1,0 +1,35 @@
+export type ByteLengthInput =
+  | string
+  | ArrayBuffer
+  | ArrayBufferView
+  | (Record<string, unknown> & { byteLength?: number });
+
+/**
+ * Ensures a byteLength estimate exists for the provided content.
+ * Returns the existing or estimated byteLength.
+ */
+export function ensureByteLength(
+  content: ByteLengthInput | undefined,
+): number | undefined {
+  if (content == null) return undefined;
+
+  const existing = (content as { byteLength?: unknown }).byteLength;
+  if (typeof existing === 'number' && Number.isFinite(existing)) {
+    return existing;
+  }
+
+  let approx: number;
+  if (typeof content === 'string') {
+    approx = content.length;
+  } else if (content instanceof ArrayBuffer || ArrayBuffer.isView(content)) {
+    approx = (content as ArrayBuffer | ArrayBufferView).byteLength;
+  } else {
+    const json = JSON.stringify(content);
+    approx = json.length;
+    // Attach the estimate for objects without byteLength
+    (content as Record<string, unknown>).byteLength = approx;
+  }
+
+  if (!Number.isFinite(approx) || approx <= 0) return undefined;
+  return approx;
+}


### PR DESCRIPTION
## Summary
- factor out byte-length estimation into reusable `ensureByteLength`
- use `ensureByteLength` in human tile loader with graceful fallback
- test byte-length estimation for string, ArrayBuffer, and object inputs

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a46e72b16c83239b383cd90fc966a2