### PR TITLE
refactor: extract parseInitialViewState helper

### DIFF
--- a/humans-globe/components/footsteps/hooks/useGlobeViewState.ts
+++ b/humans-globe/components/footsteps/hooks/useGlobeViewState.ts
@@ -1,6 +1,9 @@
 'use client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useDebouncedFlag from '@/components/footsteps/hooks/useDebouncedFlag';
+import parseInitialViewState, {
+  type ViewState,
+} from '@/lib/parseInitialViewState';
 
 type BasicViewState = {
   longitude: number;
@@ -10,49 +13,14 @@ type BasicViewState = {
   bearing?: number;
 };
 
-interface ViewState {
-  longitude: number;
-  latitude: number;
-  zoom: number;
-  pitch: number;
-  bearing: number;
-}
-
 export default function useGlobeViewState() {
   // Read optional initial state from URL query on first mount for QA/debug convenience
   // Example: ?lat=28.6&lon=77.2&zoom=8
-  const getInitialViewState = (): ViewState => {
-    try {
-      if (
-        typeof window !== 'undefined' &&
-        window.location &&
-        window.location.search
-      ) {
-        const sp = new URLSearchParams(window.location.search);
-        const lat = Number(sp.get('lat'));
-        const lon = Number(sp.get('lon') || sp.get('lng'));
-        const zoom = Number(sp.get('zoom') || sp.get('z'));
-        return {
-          longitude: Number.isFinite(lon) ? lon : 0,
-          latitude: Number.isFinite(lat) ? lat : 20,
-          zoom: Number.isFinite(zoom) ? zoom : 1.5,
-          pitch: 0,
-          bearing: 0,
-        };
-      }
-    } catch {
-      // ignore and fall back to defaults
-    }
-    return {
-      longitude: 0,
-      latitude: 20,
-      zoom: 1.5,
-      pitch: 0,
-      bearing: 0,
-    };
-  };
-
-  const [viewState, setViewState] = useState<ViewState>(getInitialViewState);
+  const [viewState, setViewState] = useState<ViewState>(() =>
+    parseInitialViewState(
+      typeof window !== 'undefined' ? window.location.search : '',
+    ),
+  );
   const viewStateRef = useRef<ViewState>(viewState);
 
   const [isZooming, triggerZoom] = useDebouncedFlag(800);

--- a/humans-globe/lib/parseInitialViewState.ts
+++ b/humans-globe/lib/parseInitialViewState.ts
@@ -1,0 +1,41 @@
+export interface ViewState {
+  longitude: number;
+  latitude: number;
+  zoom: number;
+  pitch: number;
+  bearing: number;
+}
+
+/**
+ * Parse optional map view state from a URL query string.
+ *
+ * Recognized query parameters:
+ * - `lat`: latitude in degrees (default `20`)
+ * - `lon`/`lng`: longitude in degrees (default `0`)
+ * - `zoom`/`z`: zoom level (default `1.5`)
+ *
+ * Any invalid or missing parameter falls back to its default value.
+ *
+ * @param search The query string portion of a URL (e.g. `window.location.search`).
+ * @returns Initial view state derived from the query string.
+ */
+export default function parseInitialViewState(search = ''): ViewState {
+  try {
+    const sp = new URLSearchParams(search);
+    const lat = Number(sp.get('lat'));
+    const lon = Number(sp.get('lon') || sp.get('lng'));
+    const zoom = Number(sp.get('zoom') || sp.get('z'));
+
+    return {
+      longitude: Number.isFinite(lon) ? lon : 0,
+      latitude: Number.isFinite(lat) ? lat : 20,
+      zoom: Number.isFinite(zoom) ? zoom : 1.5,
+      pitch: 0,
+      bearing: 0,
+    };
+  } catch {
+    // ignore parsing errors and fall back to defaults
+  }
+
+  return { longitude: 0, latitude: 20, zoom: 1.5, pitch: 0, bearing: 0 };
+}


### PR DESCRIPTION
## Summary
- move URL query parsing into `parseInitialViewState` helper
- initialize globe view state via new helper

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `poetry run isort footstep-generator`
- `poetry run black footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a46e7cfce483239b6593d2e32a84e7