### PR TITLE
refactor: extract human layer hook

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -7,7 +7,7 @@ import {
   createStaticTerrainLayer,
   createPlainBackgroundLayers,
 } from '@/components/footsteps/layers';
-import { createHumanLayerFactory } from '@/components/footsteps/layers/humanLayerFactory';
+import useHumanLayers from '@/components/footsteps/hooks/useHumanLayers';
 import { type LayersList } from '@deck.gl/core';
 import SupportingText from '@/components/footsteps/overlays/SupportingText';
 import LegendOverlay from '@/components/footsteps/overlays/LegendOverlay';
@@ -86,69 +86,27 @@ function FootstepsViz({ year }: FootstepsVizProps) {
   // Simplified: use viewState directly since LOD system provides stability
   const layerViewState = viewState;
 
-  const createHumanLayerForYear = useMemo(
-    () =>
-      createHumanLayerFactory({
-        is3DMode,
-        layerViewState,
-        isZooming,
-        isPanning,
-        isYearCrossfading,
-        newLayerReadyRef,
-        newLayerHasTileRef,
-        startCrossfade,
-        setTileLoading,
-        setFeatureCount,
-        setTotalPopulation,
-        setTooltipData,
-      }),
-    [
-      is3DMode,
-      layerViewState,
-      isZooming,
-      isPanning,
+  const [currentYearLayer, previousYearLayer] = useHumanLayers({
+    year,
+    lodLevel: stableLODLevel,
+    is3DMode,
+    layerViewState,
+    isZooming,
+    isPanning,
+    crossfade: {
+      prevYear: renderPrevYear,
+      currentYearOpacity: renderCurrentOpacity,
+      prevYearOpacity: renderPrevOpacity,
       isYearCrossfading,
       newLayerReadyRef,
       newLayerHasTileRef,
       startCrossfade,
-      setTileLoading,
-      setFeatureCount,
-      setTotalPopulation,
-      setTooltipData,
-    ],
-  );
-
-  // Create human tiles layers for current and (if crossfading) previous year
-  const currentYearLayer = useMemo(
-    () =>
-      createHumanLayerForYear(
-        year,
-        stableLODLevel,
-        renderCurrentOpacity,
-        `human-layer-${year}`,
-        true,
-      ),
-    [createHumanLayerForYear, year, stableLODLevel, renderCurrentOpacity],
-  );
-
-  const previousYearLayer = useMemo(
-    () =>
-      renderPrevYear !== null
-        ? createHumanLayerForYear(
-            renderPrevYear as number,
-            stableLODLevel,
-            renderPrevOpacity,
-            `human-layer-${renderPrevYear}`,
-            false,
-          )
-        : null,
-    [
-      createHumanLayerForYear,
-      renderPrevYear,
-      stableLODLevel,
-      renderPrevOpacity,
-    ],
-  );
+    },
+    setTileLoading,
+    setFeatureCount,
+    setTotalPopulation,
+    setTooltipData,
+  });
 
   // Layer ordering: background layers -> settlement points
   const layers: LayersList = previousYearLayer

--- a/humans-globe/components/footsteps/hooks/useHumanLayers.ts
+++ b/humans-globe/components/footsteps/hooks/useHumanLayers.ts
@@ -1,0 +1,116 @@
+import { useMemo } from 'react';
+import type { MutableRefObject } from 'react';
+import { createHumanLayerFactory } from '@/components/footsteps/layers/humanLayerFactory';
+
+interface CrossfadeRefs {
+  prevYear: number | null;
+  currentYearOpacity: number;
+  prevYearOpacity: number;
+  isYearCrossfading: boolean;
+  newLayerReadyRef: MutableRefObject<boolean>;
+  newLayerHasTileRef: MutableRefObject<boolean>;
+  startCrossfade: () => void;
+}
+
+interface UseHumanLayersOptions {
+  year: number;
+  lodLevel: number;
+  is3DMode: boolean;
+  layerViewState: { zoom?: number } | null;
+  isZooming: boolean;
+  isPanning: boolean;
+  crossfade: CrossfadeRefs;
+  setTileLoading: (loading: boolean) => void;
+  setFeatureCount: (count: number) => void;
+  setTotalPopulation: (total: number) => void;
+  setTooltipData: (
+    data: {
+      population: number;
+      coordinates: [number, number];
+      year: number;
+      settlementType?: string;
+      clickPosition: { x: number; y: number };
+    } | null,
+  ) => void;
+}
+
+export default function useHumanLayers(options: UseHumanLayersOptions) {
+  const {
+    year,
+    lodLevel,
+    is3DMode,
+    layerViewState,
+    isZooming,
+    isPanning,
+    crossfade,
+    setTileLoading,
+    setFeatureCount,
+    setTotalPopulation,
+    setTooltipData,
+  } = options;
+
+  const createHumanLayerForYear = useMemo(
+    () =>
+      createHumanLayerFactory({
+        is3DMode,
+        layerViewState,
+        isZooming,
+        isPanning,
+        isYearCrossfading: crossfade.isYearCrossfading,
+        newLayerReadyRef: crossfade.newLayerReadyRef,
+        newLayerHasTileRef: crossfade.newLayerHasTileRef,
+        startCrossfade: crossfade.startCrossfade,
+        setTileLoading,
+        setFeatureCount,
+        setTotalPopulation,
+        setTooltipData,
+      }),
+    [
+      is3DMode,
+      layerViewState,
+      isZooming,
+      isPanning,
+      crossfade.isYearCrossfading,
+      crossfade.newLayerReadyRef,
+      crossfade.newLayerHasTileRef,
+      crossfade.startCrossfade,
+      setTileLoading,
+      setFeatureCount,
+      setTotalPopulation,
+      setTooltipData,
+    ],
+  );
+
+  const currentLayer = useMemo(
+    () =>
+      createHumanLayerForYear(
+        year,
+        lodLevel,
+        crossfade.currentYearOpacity,
+        `human-layer-${year}`,
+        true,
+      ),
+    [createHumanLayerForYear, year, lodLevel, crossfade.currentYearOpacity],
+  );
+
+  const previousLayer = useMemo(
+    () =>
+      crossfade.prevYear !== null
+        ? createHumanLayerForYear(
+            crossfade.prevYear as number,
+            lodLevel,
+            crossfade.prevYearOpacity,
+            `human-layer-${crossfade.prevYear}`,
+            false,
+          )
+        : null,
+    [
+      createHumanLayerForYear,
+      crossfade.prevYear,
+      lodLevel,
+      crossfade.prevYearOpacity,
+    ],
+  );
+
+  return [currentLayer, previousLayer] as const;
+}


### PR DESCRIPTION
## Summary
- add `useHumanLayers` hook to build current and previous human layers
- simplify `FootstepsViz` by using the new hook

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run isort --check footstep-generator` (fails: imports not sorted)
- `poetry run black --check footstep-generator` (fails: would reformat files)
- `poetry run pytest footstep-generator -q` (fails: ModuleNotFoundError: No module named 'pydantic')

------
https://chatgpt.com/codex/tasks/task_e_68a46ed79b9c8323b9244d1f9f6c4a41