### PR TITLE
perf: use binary search for year snapping

### DIFF
--- a/humans-globe/lib/useYear.test.ts
+++ b/humans-globe/lib/useYear.test.ts
@@ -14,6 +14,16 @@ describe('yearToSlider and sliderToYear', () => {
     expect(sliderToYear(yearToSlider(0))).toBe(0);
   });
 
+  it('clamps slider positions outside the 0-100 range', () => {
+    expect(sliderToYear(-10)).toBe(-10000);
+    expect(sliderToYear(110)).toBe(1500);
+  });
+
+  it('chooses the lower year when equidistant', () => {
+    const pos = yearToSlider(50);
+    expect(sliderToYear(pos)).toBe(0);
+  });
+
   it('round trips target years', () => {
     const targetYears = [
       -10000, -9000, -8000, -7000, -6000, -5000, -4000, -3000, -2000, -1000, 0,

--- a/humans-globe/lib/useYear.ts
+++ b/humans-globe/lib/useYear.ts
@@ -72,25 +72,40 @@ function getYearFromScaledPosition(position: number): number {
   return Math.round(year);
 }
 
-// Convert slider position (0-100) to year (snaps to available target years)
+// Convert slider position (0-100) to year.
+// Uses binary search to snap to the closest value in TARGET_YEARS.
 export function sliderToYear(position: number): number {
   const clamped = Math.min(Math.max(position, 0), 100);
   // Map slider 0-100 back to raw position
   const rawPos = (clamped / 100) * RAW_MAX_POSITION;
   const theoreticalYear = getYearFromScaledPosition(rawPos);
 
-  // Snap to nearest target year
-  let closestYear = TARGET_YEARS[0];
-  let minDistance = Math.abs(theoreticalYear - closestYear);
+  // Snap to nearest target year using binary search for efficiency
+  let low = 0;
+  let high = TARGET_YEARS.length - 1;
 
-  for (const targetYear of TARGET_YEARS) {
-    const distance = Math.abs(theoreticalYear - targetYear);
-    if (distance < minDistance) {
-      minDistance = distance;
-      closestYear = targetYear;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const midYear = TARGET_YEARS[mid];
+    if (midYear === theoreticalYear) {
+      return midYear;
+    }
+    if (midYear < theoreticalYear) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
     }
   }
-  return closestYear;
+
+  if (low >= TARGET_YEARS.length) return TARGET_YEARS[TARGET_YEARS.length - 1];
+  if (high < 0) return TARGET_YEARS[0];
+
+  const lowerYear = TARGET_YEARS[high];
+  const upperYear = TARGET_YEARS[low];
+
+  return theoreticalYear - lowerYear <= upperYear - theoreticalYear
+    ? lowerYear
+    : upperYear;
 }
 
 // Custom hook for year state management


### PR DESCRIPTION
## Summary
- replace linear search in `sliderToYear` with binary search
- add edge case tests for `sliderToYear`
- document binary search approach in `sliderToYear`

## Testing
- `pnpm lint`
- `pnpm exec prettier lib/useYear.ts lib/useYear.test.ts --write`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a46f3283bc8323966669daca9f93fb