### PR TITLE
refactor: modularize human tile helpers

### DIFF
--- a/humans-globe/components/footsteps/layers/color.test.ts
+++ b/humans-globe/components/footsteps/layers/color.test.ts
@@ -1,0 +1,26 @@
+import { getFillColor } from './color';
+
+describe('getFillColor', () => {
+  it('returns base color based on population', () => {
+    expect(getFillColor({ properties: { population: 25000 } })).toEqual([
+      255, 100, 0, 240,
+    ]);
+    expect(getFillColor({ properties: { population: 6000 } })).toEqual([
+      255, 140, 0, 220,
+    ]);
+    expect(getFillColor({ properties: { population: 1500 } })).toEqual([
+      255, 180, 0, 200,
+    ]);
+    expect(getFillColor({ properties: { population: 500 } })).toEqual([
+      255, 200, 100, 180,
+    ]);
+  });
+
+  it('applies debug tint', () => {
+    const color = getFillColor(
+      { properties: { population: 1500 } },
+      [10, 20, 30],
+    );
+    expect(color).toEqual([255, 200, 30, 200]);
+  });
+});

--- a/humans-globe/components/footsteps/layers/color.ts
+++ b/humans-globe/components/footsteps/layers/color.ts
@@ -1,0 +1,27 @@
+// Determine fill color based on population and optional debug tint
+export function getFillColor(
+  feature: unknown,
+  debugTint?: [number, number, number],
+): [number, number, number, number] {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const population = Number((feature as any)?.properties?.population || 0);
+    // Use fixed alpha; rely on layer.opacity for crossfades to avoid double-dimming
+    let base: [number, number, number, number];
+    if (population > 20000) base = [255, 100, 0, 240];
+    else if (population > 5000) base = [255, 140, 0, 220];
+    else if (population > 1000) base = [255, 180, 0, 200];
+    else base = [255, 200, 100, 180];
+    // Apply optional debug tint to help visualize crossfade layers in dev
+    if (debugTint && Array.isArray(debugTint)) {
+      const clamp = (v: number) => Math.max(0, Math.min(255, v));
+      const r = clamp(base[0] + debugTint[0]);
+      const g = clamp(base[1] + debugTint[1]);
+      const b = clamp(base[2] + debugTint[2]);
+      return [r, g, b, base[3]] as [number, number, number, number];
+    }
+    return base;
+  } catch {
+    return [255, 200, 100, 180];
+  }
+}

--- a/humans-globe/components/footsteps/layers/humanLayer.ts
+++ b/humans-globe/components/footsteps/layers/humanLayer.ts
@@ -1,21 +1,9 @@
 import { MVTLayer } from '@deck.gl/geo-layers';
 import { getTileUrlPattern } from '@/lib/tilesConfig';
 import { radiusStrategies, type RadiusStrategy } from './radiusStrategies';
-
-// Helper: map population to a base display radius in meters
-function getBaseRadiusFromPopulation(population: number): number {
-  if (population > 1_000_000) return 60000; // Super cities: 60km
-  if (population > 100_000) return 40000; // Massive cities: 40km
-  if (population > 50_000) return 25000; // Major cities: 25km
-  if (population > 20_000) return 15000; // Large settlements: 15km
-  if (population > 5_000) return 8000; // Medium settlements: 8km
-  if (population > 1_000) return 4000; // Small settlements: 4km
-  if (population > 100) return 2000; // Villages: 2km
-  return 1000; // Tiny settlements: 1km
-}
-
-// Global layer counter to ensure unique IDs
-let layerCounter = 0;
+import { getPointRadius } from './radius';
+import { createLayerId, createOnTileLoadHandler } from './tileCache';
+import { getFillColor } from './color';
 
 // Create MVT-based human tiles layer
 export function createHumanTilesLayer(
@@ -58,18 +46,11 @@ export function createHumanTilesLayer(
     (extra && 'tileOptions' in extra ? extra.tileOptions : undefined) || {};
 
   // Generate unique layer ID to prevent deck.gl assertion failures from layer reuse
-  const baseId = `human-tiles-${year}-single-${radiusStrategy.getName()}`;
-  const layerId = instanceId || `${baseId}-${++layerCounter}-${Date.now()}`;
+  const layerId = createLayerId(year, radiusStrategy, instanceId);
 
   // Clamp tile zooms to the ranges actually present in each LOD's MBTiles.
   // This prevents deck.gl from requesting higher z tiles than exist when the
   // viewport zoom is between integer levels (e.g. z=4.8 with LOD 1 → still use z=4 tiles).
-  const lodZoomRanges: Record<number, { min: number; max: number }> = {
-    0: { min: 0, max: 3 },
-    1: { min: 4, max: 4 },
-    2: { min: 5, max: 5 },
-    3: { min: 6, max: 12 },
-  };
   const zoomRange = { min: 0, max: 12 };
 
   return new MVTLayer({
@@ -102,47 +83,7 @@ export function createHumanTilesLayer(
     onClick: onClick || (() => {}),
     onHover: onHover || (() => {}),
     // Ensure deck.gl always receives callable callbacks to avoid TypeErrors
-    onTileLoad: (tile: unknown) => {
-      try {
-        // Attach an approximate byteLength so Tileset2D doesn't error
-        const t = tile as { content?: unknown };
-        const content = t && 'content' in t ? (t as any).content : undefined;
-        const hasFiniteByteLength =
-          typeof (content as any)?.byteLength === 'number' &&
-          Number.isFinite((content as any).byteLength);
-        if (content && !hasFiniteByteLength) {
-          let approx = 0;
-          try {
-            if (typeof content === 'string') {
-              approx = content.length;
-            } else if (
-              content instanceof ArrayBuffer ||
-              ArrayBuffer.isView(content)
-            ) {
-              // Covers ArrayBuffer and typed arrays
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              approx = (content as any).byteLength || 0;
-            } else {
-              // Fall back to JSON size estimate for GeoJSON-like objects
-              approx = JSON.stringify(content).length;
-            }
-          } catch {
-            // Ignore estimation errors; leave undefined
-          }
-          if (Number.isFinite(approx) && approx > 0) {
-            try {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (content as any).byteLength = approx;
-            } catch {
-              // If content is not extensible, ignore
-            }
-          }
-        }
-      } catch {
-        // Swallow any defensive errors here
-      }
-      if (typeof extra?.onTileLoad === 'function') extra.onTileLoad(tile);
-    },
+    onTileLoad: createOnTileLoadHandler(extra?.onTileLoad),
     onViewportLoad:
       typeof extra?.onViewportLoad === 'function'
         ? extra?.onViewportLoad
@@ -153,41 +94,13 @@ export function createHumanTilesLayer(
     pointRadiusUnits: 'meters',
     getPointRadius: (f: unknown) => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const feature = f as any;
-        const pop = Number(feature?.properties?.population || 0);
-        const base = getBaseRadiusFromPopulation(pop);
-        const radius = radiusStrategy.calculateRadius(base, currentZoom);
-        return radius;
+        return getPointRadius(f, currentZoom, radiusStrategy);
       } catch (error) {
         console.error(`[RADIUS-ERROR]:`, error);
         return 2000;
       }
     },
-    getFillColor: (f: unknown) => {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const population = Number((f as any)?.properties?.population || 0);
-        // Use fixed alpha; rely on layer.opacity for crossfades to avoid double-dimming
-        let base: [number, number, number, number];
-        if (population > 20000) base = [255, 100, 0, 240];
-        else if (population > 5000) base = [255, 140, 0, 220];
-        else if (population > 1000) base = [255, 180, 0, 200];
-        else base = [255, 200, 100, 180];
-        // Apply optional debug tint to help visualize crossfade layers in dev
-        const tint = extra?.debugTint;
-        if (tint && Array.isArray(tint)) {
-          const clamp = (v: number) => Math.max(0, Math.min(255, v));
-          const r = clamp(base[0] + tint[0]);
-          const g = clamp(base[1] + tint[1]);
-          const b = clamp(base[2] + tint[2]);
-          return [r, g, b, base[3]] as [number, number, number, number];
-        }
-        return base;
-      } catch {
-        return [255, 200, 100, 180];
-      }
-    },
+    getFillColor: (f: unknown) => getFillColor(f, extra?.debugTint),
     updateTriggers: {
       getPointRadius: [
         year,

--- a/humans-globe/components/footsteps/layers/radius.test.ts
+++ b/humans-globe/components/footsteps/layers/radius.test.ts
@@ -1,0 +1,28 @@
+import { getBaseRadiusFromPopulation, getPointRadius } from './radius';
+import { radiusStrategies } from './radiusStrategies';
+
+describe('getBaseRadiusFromPopulation', () => {
+  it('maps population ranges to expected radii', () => {
+    expect(getBaseRadiusFromPopulation(2_000_000)).toBe(60000);
+    expect(getBaseRadiusFromPopulation(150_000)).toBe(40000);
+    expect(getBaseRadiusFromPopulation(60_000)).toBe(25000);
+    expect(getBaseRadiusFromPopulation(25_000)).toBe(15000);
+    expect(getBaseRadiusFromPopulation(10_000)).toBe(8000);
+    expect(getBaseRadiusFromPopulation(2_000)).toBe(4000);
+    expect(getBaseRadiusFromPopulation(500)).toBe(2000);
+    expect(getBaseRadiusFromPopulation(50)).toBe(1000);
+  });
+});
+
+describe('getPointRadius', () => {
+  const feature = { properties: { population: 2_000 } };
+  it('uses linear strategy without scaling', () => {
+    const radius = getPointRadius(feature, 5, radiusStrategies.linear);
+    expect(radius).toBe(4000);
+  });
+  it('applies zoom-adaptive strategy scaling', () => {
+    const radius = getPointRadius(feature, 2, radiusStrategies.zoomAdaptive);
+    // zoom 2 -> multiplier 6 according to strategy
+    expect(radius).toBe(4000 * 6);
+  });
+});

--- a/humans-globe/components/footsteps/layers/radius.ts
+++ b/humans-globe/components/footsteps/layers/radius.ts
@@ -1,0 +1,25 @@
+import { RadiusStrategy } from './radiusStrategies';
+
+// Map population to a base display radius in meters
+export function getBaseRadiusFromPopulation(population: number): number {
+  if (population > 1_000_000) return 60000; // Super cities: 60km
+  if (population > 100_000) return 40000; // Massive cities: 40km
+  if (population > 50_000) return 25000; // Major cities: 25km
+  if (population > 20_000) return 15000; // Large settlements: 15km
+  if (population > 5_000) return 8000; // Medium settlements: 8km
+  if (population > 1_000) return 4000; // Small settlements: 4km
+  if (population > 100) return 2000; // Villages: 2km
+  return 1000; // Tiny settlements: 1km
+}
+
+// Calculate radius for a feature using a strategy
+export function getPointRadius(
+  feature: unknown,
+  zoom: number,
+  strategy: RadiusStrategy,
+): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pop = Number((feature as any)?.properties?.population || 0);
+  const base = getBaseRadiusFromPopulation(pop);
+  return strategy.calculateRadius(base, zoom);
+}

--- a/humans-globe/components/footsteps/layers/tileCache.test.ts
+++ b/humans-globe/components/footsteps/layers/tileCache.test.ts
@@ -1,0 +1,29 @@
+import { createLayerId, createOnTileLoadHandler } from './tileCache';
+import { radiusStrategies } from './radiusStrategies';
+
+describe('createLayerId', () => {
+  it('returns provided instance id', () => {
+    const id = createLayerId(2020, radiusStrategies.linear, 'instance');
+    expect(id).toBe('instance');
+  });
+
+  it('generates unique ids when instance id not provided', () => {
+    const id1 = createLayerId(2020, radiusStrategies.linear);
+    const id2 = createLayerId(2020, radiusStrategies.linear);
+    expect(id1).not.toBe(id2);
+    expect(id1).toContain('human-tiles-2020-single-linear');
+  });
+});
+
+describe('createOnTileLoadHandler', () => {
+  it('patches byteLength and forwards call', () => {
+    const extra = jest.fn();
+    const handler = createOnTileLoadHandler(extra);
+    const tile: { content?: unknown } = { content: { foo: 'bar' } };
+    handler(tile);
+    expect(
+      (tile.content as { byteLength?: number }).byteLength,
+    ).toBeGreaterThan(0);
+    expect(extra).toHaveBeenCalledWith(tile);
+  });
+});

--- a/humans-globe/components/footsteps/layers/tileCache.ts
+++ b/humans-globe/components/footsteps/layers/tileCache.ts
@@ -1,0 +1,61 @@
+import { RadiusStrategy } from './radiusStrategies';
+
+// Global layer counter to ensure unique IDs
+let layerCounter = 0;
+
+export function createLayerId(
+  year: number,
+  strategy: RadiusStrategy,
+  instanceId?: string,
+): string {
+  const baseId = `human-tiles-${year}-single-${strategy.getName()}`;
+  return instanceId || `${baseId}-${++layerCounter}-${Date.now()}`;
+}
+
+export function patchTileByteLength(tile: unknown): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = tile as any;
+    const content = t && 'content' in t ? t.content : undefined;
+    const hasFiniteByteLength =
+      typeof content?.byteLength === 'number' &&
+      Number.isFinite(content.byteLength);
+    if (content && !hasFiniteByteLength) {
+      let approx = 0;
+      try {
+        if (typeof content === 'string') {
+          approx = content.length;
+        } else if (
+          content instanceof ArrayBuffer ||
+          ArrayBuffer.isView(content)
+        ) {
+          // Covers ArrayBuffer and typed arrays
+          approx = (content as ArrayBufferLike).byteLength || 0;
+        } else {
+          // Fall back to JSON size estimate for GeoJSON-like objects
+          approx = JSON.stringify(content).length;
+        }
+      } catch {
+        // Ignore estimation errors; leave undefined
+      }
+      if (Number.isFinite(approx) && approx > 0) {
+        try {
+          (content as { byteLength?: number }).byteLength = approx;
+        } catch {
+          // If content is not extensible, ignore
+        }
+      }
+    }
+  } catch {
+    // Swallow any defensive errors here
+  }
+}
+
+export function createOnTileLoadHandler(
+  extra?: (tile: unknown) => void,
+): (tile: unknown) => void {
+  return (tile: unknown) => {
+    patchTileByteLength(tile);
+    if (typeof extra === 'function') extra(tile);
+  };
+}


### PR DESCRIPTION
## Summary
- extract radius, tile cache, and color utilities into dedicated modules
- simplify createHumanTilesLayer to delegate helper logic
- add unit tests for radius, tile cache, and color helpers

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black --check footstep-generator` *(fails: 31 files would be reformatted)*
- `poetry run isort --check footstep-generator` *(fails: imports incorrectly sorted)*
- `poetry run pytest footstep-generator -q` *(fails: missing modules pydantic, numpy, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f1731a48323921b862fc273ff52