### PR TITLE
refactor: migrate view mode store to hook

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, memo } from 'react';
-import { getViewMode, setViewMode } from '@/lib/viewModeStore';
+import { useViewMode } from '@/lib/viewModeStore';
 import { getLODLevel } from '@/lib/lod';
 import {
   createStaticTerrainLayer,
@@ -22,8 +22,8 @@ interface FootstepsVizProps {
 }
 
 function FootstepsViz({ year }: FootstepsVizProps) {
-  // View mode toggle state with cookie persistence for SSR compatibility
-  const [is3DMode, setIs3DMode] = useState(() => getViewMode());
+  // View mode toggle state with cookie persistence
+  const [is3DMode, setIs3DMode] = useViewMode();
 
   // Terrain toggle state - default to plain mode for better dot visibility
   const [showTerrain, setShowTerrain] = useState(false);
@@ -40,11 +40,6 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     settlementType?: string;
     clickPosition: { x: number; y: number };
   } | null>(null);
-
-  // Save view mode preference to cookie
-  useEffect(() => {
-    setViewMode(is3DMode);
-  }, [is3DMode]);
 
   // Removed complex viewport bounds system - tiles handle spatial filtering efficiently
 

--- a/humans-globe/lib/viewModeStore.ts
+++ b/humans-globe/lib/viewModeStore.ts
@@ -1,73 +1,55 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 /**
- * View mode persistence utility using cookies for SSR compatibility
- * Handles 2D/3D globe view preference storage
+ * View mode persistence using cookies for SSR compatibility
+ * Provides a React hook and utility functions for non-React callers
  */
 
 const COOKIE_NAME = 'globe-view-mode';
 const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year in seconds
 
-export class ViewModeStore {
-  private static instance: ViewModeStore;
-  
-  private constructor() {}
-  
-  static getInstance(): ViewModeStore {
-    if (!ViewModeStore.instance) {
-      ViewModeStore.instance = new ViewModeStore();
-    }
-    return ViewModeStore.instance;
-  }
-  
-  /**
-   * Get current view mode from cookie
-   * Works on both server and client for SSR compatibility
-   */
-  getViewMode(): boolean {
-    if (typeof document === 'undefined') {
-      return false; // Default to 2D for server-side rendering
-    }
-    
-    try {
-      const cookieValue = document.cookie
-        .split('; ')
-        .find(row => row.startsWith(`${COOKIE_NAME}=`))
-        ?.split('=')[1];
-      
-      return cookieValue === 'true';
-    } catch (error) {
-      console.warn('Failed to read view mode cookie:', error);
-      return false;
-    }
-  }
-  
-  /**
-   * Set view mode preference in cookie
-   * Only works on client side
-   */
-  setViewMode(is3DMode: boolean): void {
-    if (typeof document === 'undefined') {
-      return; // No-op on server
-    }
-    
-    try {
-      document.cookie = `${COOKIE_NAME}=${is3DMode}; max-age=${COOKIE_MAX_AGE}; path=/; SameSite=Lax`;
-    } catch (error) {
-      console.warn('Failed to set view mode cookie:', error);
-    }
-  }
-}
-
-/**
- * Convenience functions for direct use
- */
-export const viewModeStore = ViewModeStore.getInstance();
-
 export function getViewMode(): boolean {
-  return viewModeStore.getViewMode();
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  try {
+    const cookieValue = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith(`${COOKIE_NAME}=`))
+      ?.split('=')[1];
+
+    return cookieValue === 'true';
+  } catch (error) {
+    console.warn('Failed to read view mode cookie:', error);
+    return false;
+  }
 }
 
 export function setViewMode(is3DMode: boolean): void {
-  viewModeStore.setViewMode(is3DMode);
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  try {
+    document.cookie = `${COOKIE_NAME}=${is3DMode}; max-age=${COOKIE_MAX_AGE}; path=/; SameSite=Lax`;
+  } catch (error) {
+    console.warn('Failed to set view mode cookie:', error);
+  }
+}
+
+export function useViewMode(): [boolean, (is3DMode: boolean) => void] {
+  const [is3DMode, setIs3DMode] = useState(false);
+
+  useEffect(() => {
+    setIs3DMode(getViewMode());
+  }, []);
+
+  useEffect(() => {
+    setViewMode(is3DMode);
+  }, [is3DMode]);
+
+  return [is3DMode, setIs3DMode];
 }


### PR DESCRIPTION
## Summary
- replace class-based view mode store with hook and cookie helpers
- consume new `useViewMode` hook in `FootstepsViz`

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black footstep-generator --check` *(fails: would reformat 31 files)*
- `poetry run isort footstep-generator --check` *(fails: imports incorrectly sorted)*
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a46f4721f08323b7218be2d845f0fb