### PR TITLE
refactor(ui): move slider inline styles to CSS classes

### DIFF
--- a/humans-globe/app/globals.css
+++ b/humans-globe/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @source "./**/*.{js,ts,jsx,tsx,mdx}";
 @source "../components/**/*.{js,ts,jsx,tsx,mdx}";
 @import 'rc-slider/assets/index.css';
@@ -63,4 +63,30 @@ main {
 .rc-slider-mark-text-active:last-of-type {
   color: #38bdf8 !important; /* Accent colour */
   font-weight: 600;
+}
+
+@layer components {
+  .time-slider-container {
+    @apply fixed bottom-8 left-8 right-8 z-40 bg-black/80 backdrop-blur-sm rounded-lg p-6;
+  }
+
+  .time-slider .rc-slider-track {
+    @apply bg-sky-500 h-1.5;
+  }
+
+  .time-slider .rc-slider-rail {
+    @apply bg-slate-700 h-1.5;
+  }
+
+  .time-slider .rc-slider-handle {
+    @apply bg-slate-800 border-[3px] border-sky-500 w-6 h-6 mt-[-9px] shadow-[0_0_10px_rgba(14,165,233,0.5)];
+  }
+
+  .time-slider .rc-slider-dot {
+    @apply bg-slate-600 border-2 border-slate-500;
+  }
+
+  .time-slider .rc-slider-dot-active {
+    @apply bg-sky-500 border-2 border-sky-400;
+  }
 }

--- a/humans-globe/components/ui/TimeSlider.tsx
+++ b/humans-globe/components/ui/TimeSlider.tsx
@@ -14,10 +14,7 @@ export default function TimeSlider({ value, onChange }: TimeSliderProps) {
   const currentYear = sliderToYear(value);
 
   return (
-    <div
-      className="fixed bg-black/80 backdrop-blur-sm rounded-lg p-6"
-      style={{ bottom: '2rem', left: '2rem', right: '2rem', zIndex: 40 }}
-    >
+    <div className="time-slider-container">
       <div className="w-full">
         {/* Current year display */}
         <div className="flex items-center justify-end mb-4">
@@ -37,25 +34,7 @@ export default function TimeSlider({ value, onChange }: TimeSliderProps) {
             }
             marks={marks}
             step={0.1}
-            className="mb-8 w-full"
-            trackStyle={{ backgroundColor: '#0ea5e9', height: 6 }}
-            railStyle={{ backgroundColor: '#334155', height: 6 }}
-            handleStyle={{
-              backgroundColor: '#1e293b',
-              border: '3px solid #0ea5e9',
-              width: 24,
-              height: 24,
-              marginTop: -9,
-              boxShadow: '0 0 10px rgba(14, 165, 233, 0.5)',
-            }}
-            dotStyle={{
-              backgroundColor: '#475569',
-              border: '2px solid #64748b',
-            }}
-            activeDotStyle={{
-              backgroundColor: '#0ea5e9',
-              border: '2px solid #38bdf8',
-            }}
+            className="time-slider mb-8 w-full"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `time-slider-container` and `time-slider` classes
- replace inline `rc-slider` styles with Tailwind utilities

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black footstep-generator --check` *(fails: would reformat files)*
- `poetry run isort footstep-generator --check` *(fails: 31 files would be reformatted)*
- `poetry run pytest footstep-generator -q` *(fails: imports are incorrectly sorted)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f6553208323b5acf24f78edf8d3