### PR TITLE
refactor: reuse background layer instances

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -4,8 +4,9 @@ import { useState, useMemo, useEffect, memo } from 'react';
 import { getViewMode, setViewMode } from '@/lib/viewModeStore';
 import { getLODLevel } from '@/lib/lod';
 import {
-  createStaticTerrainLayer,
-  createPlainBackgroundLayers,
+  SEA_LAYER,
+  CONTINENTS_LAYER,
+  TERRAIN_LAYER,
 } from '@/components/footsteps/layers';
 import { createHumanLayerFactory } from '@/components/footsteps/layers/humanLayerFactory';
 import { type LayersList } from '@deck.gl/core';
@@ -72,9 +73,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
 
   // Background layers - terrain or plain based on toggle
   const backgroundLayers = useMemo(() => {
-    return showTerrain
-      ? [createStaticTerrainLayer()]
-      : createPlainBackgroundLayers();
+    return showTerrain ? [TERRAIN_LAYER] : [SEA_LAYER, CONTINENTS_LAYER];
   }, [showTerrain]);
 
   // Stable LOD level for memoization - only changes at discrete boundaries

--- a/humans-globe/components/footsteps/layers/backgroundLayers.ts
+++ b/humans-globe/components/footsteps/layers/backgroundLayers.ts
@@ -1,6 +1,122 @@
 import { GeoJsonLayer, BitmapLayer } from '@deck.gl/layers';
 import { TileLayer } from '@deck.gl/geo-layers';
 
+// Cached background layer instances
+export const SEA_LAYER = new GeoJsonLayer({
+  id: 'plain-sea',
+  data: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-180, -90],
+              [180, -90],
+              [180, 90],
+              [-180, 90],
+              [-180, -90],
+            ],
+          ],
+        },
+      },
+    ],
+  },
+  filled: true,
+  stroked: false,
+  getFillColor: [20, 30, 45, 255], // Dark blue for sea
+  pickable: false,
+  opacity: 1.0,
+  parameters: {
+    depthTest: true,
+    depthMask: true,
+    blend: false,
+  },
+});
+
+export const CONTINENTS_LAYER = new GeoJsonLayer({
+  id: 'plain-continents',
+  // Using a more reliable CDN for world land data
+  data: 'https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/world.geojson',
+  filled: true,
+  stroked: false,
+  getFillColor: [15, 15, 15, 255], // Very dark gray/black for continents
+  pickable: false,
+  opacity: 1.0,
+  parameters: {
+    depthTest: true,
+    depthMask: false, // Don't write to depth buffer so dots render on top
+    blend: true,
+  },
+});
+
+export const TERRAIN_LAYER = new TileLayer({
+  id: 'terrain-layer',
+  // Using satellite imagery that shows natural land and water colors without labels
+  data: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+  maxZoom: 8,
+  minZoom: 0,
+  // Provide no-op callbacks to satisfy deck.gl TileLayer expectations
+  onTileLoad: () => {},
+  onViewportLoad: () => {},
+  onTileError: () => {},
+  // Only render the sub-layer once the tile image has loaded.
+  // Otherwise DeckGL will attempt to create a BitmapLayer with
+  // an undefined image which triggers an `assert` failure under
+  // WebGL. This manifests as large dark artefacts on first load
+  // when the page is opened directly in 3-D mode.
+  renderSubLayers: (props) => {
+    // Skip if tile image hasn't loaded yet
+    if (!props.data) {
+      return null;
+    }
+
+    // Defensive: ensure bounding box exists & values are finite
+    const { boundingBox } = props.tile ?? {};
+    if (
+      !boundingBox ||
+      !Number.isFinite(boundingBox[0]?.[0]) ||
+      !Number.isFinite(boundingBox[0]?.[1]) ||
+      !Number.isFinite(boundingBox[1]?.[0]) ||
+      !Number.isFinite(boundingBox[1]?.[1])
+    ) {
+      /* eslint-disable no-console */
+      console.warn(
+        '[terrain-layer] invalid boundingBox, skipping sub-layer',
+        boundingBox,
+      );
+      /* eslint-enable no-console */
+      return null;
+    }
+
+    return new BitmapLayer(props, {
+      id: `${props.id}-bitmap`,
+      data: undefined,
+      image: props.data,
+      bounds: [
+        boundingBox[0][0],
+        boundingBox[0][1],
+        boundingBox[1][0],
+        boundingBox[1][1],
+      ],
+      // Small optimisation: disable updates once image is set
+      updateTriggers: {
+        image: props.data,
+      },
+    });
+  },
+  pickable: false,
+  opacity: 1.0, // Full opacity to prevent seeing through globe
+  parameters: {
+    depthTest: true, // Enable depth testing for proper layering
+    depthMask: true, // Write to depth buffer to block background
+    blend: false, // Disable blending for solid coverage
+  },
+});
+
 // Create basemap layer
 export function createBasemapLayer(data: unknown, basemapError: boolean) {
   return new GeoJsonLayer({
@@ -66,123 +182,10 @@ export function createEarthSphereLayer() {
 
 // Create static terrain layer for land/water visualization
 export function createStaticTerrainLayer() {
-  return new TileLayer({
-    id: 'terrain-layer',
-    // Using satellite imagery that shows natural land and water colors without labels
-    data: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-    maxZoom: 8,
-    minZoom: 0,
-    // Provide no-op callbacks to satisfy deck.gl TileLayer expectations
-    onTileLoad: () => {},
-    onViewportLoad: () => {},
-    onTileError: () => {},
-    // Only render the sub-layer once the tile image has loaded.
-    // Otherwise DeckGL will attempt to create a BitmapLayer with
-    // an undefined image which triggers an `assert` failure under
-    // WebGL. This manifests as large dark artefacts on first load
-    // when the page is opened directly in 3-D mode.
-    renderSubLayers: (props) => {
-      // Skip if tile image hasn't loaded yet
-      if (!props.data) {
-        return null;
-      }
-
-      // Defensive: ensure bounding box exists & values are finite
-      const { boundingBox } = props.tile ?? {};
-      if (
-        !boundingBox ||
-        !Number.isFinite(boundingBox[0]?.[0]) ||
-        !Number.isFinite(boundingBox[0]?.[1]) ||
-        !Number.isFinite(boundingBox[1]?.[0]) ||
-        !Number.isFinite(boundingBox[1]?.[1])
-      ) {
-        /* eslint-disable no-console */
-        console.warn(
-          '[terrain-layer] invalid boundingBox, skipping sub-layer',
-          boundingBox,
-        );
-        /* eslint-enable no-console */
-        return null;
-      }
-
-      return new BitmapLayer(props, {
-        id: `${props.id}-bitmap`,
-        data: undefined,
-        image: props.data,
-        bounds: [
-          boundingBox[0][0],
-          boundingBox[0][1],
-          boundingBox[1][0],
-          boundingBox[1][1],
-        ],
-        // Small optimisation: disable updates once image is set
-        updateTriggers: {
-          image: props.data,
-        },
-      });
-    },
-    pickable: false,
-    opacity: 1.0, // Full opacity to prevent seeing through globe
-    parameters: {
-      depthTest: true, // Enable depth testing for proper layering
-      depthMask: true, // Write to depth buffer to block background
-      blend: false, // Disable blending for solid coverage
-    },
-  });
+  return TERRAIN_LAYER;
 }
 
 // Create plain background layers for better dot visibility
 export function createPlainBackgroundLayers() {
-  const seaLayer = new GeoJsonLayer({
-    id: 'plain-sea',
-    data: {
-      type: 'FeatureCollection',
-      features: [
-        {
-          type: 'Feature',
-          properties: {},
-          geometry: {
-            type: 'Polygon',
-            coordinates: [
-              [
-                [-180, -90],
-                [180, -90],
-                [180, 90],
-                [-180, 90],
-                [-180, -90],
-              ],
-            ],
-          },
-        },
-      ],
-    },
-    filled: true,
-    stroked: false,
-    getFillColor: [20, 30, 45, 255], // Dark blue for sea
-    pickable: false,
-    opacity: 1.0,
-    parameters: {
-      depthTest: true,
-      depthMask: true,
-      blend: false,
-    },
-  });
-
-  const continentsLayer = new GeoJsonLayer({
-    id: 'plain-continents',
-    // Using a more reliable CDN for world land data
-    data: 'https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/world.geojson',
-    filled: true,
-    stroked: false,
-    getFillColor: [15, 15, 15, 255], // Very dark gray/black for continents
-    pickable: false,
-    opacity: 1.0,
-    parameters: {
-      depthTest: true,
-      depthMask: false, // Don't write to depth buffer so dots render on top
-      blend: true,
-    },
-  });
-
-  return [seaLayer, continentsLayer];
+  return [SEA_LAYER, CONTINENTS_LAYER];
 }

--- a/humans-globe/components/footsteps/layers/index.ts
+++ b/humans-globe/components/footsteps/layers/index.ts
@@ -6,5 +6,8 @@ export {
   createEarthSphereLayer,
   createStaticTerrainLayer,
   createPlainBackgroundLayers,
+  SEA_LAYER,
+  CONTINENTS_LAYER,
+  TERRAIN_LAYER,
 } from './backgroundLayers';
 export { createHumanTilesLayer } from './humanLayer';


### PR DESCRIPTION
## Summary
- export and cache static background layers for sea, continents and terrain
- reference cached layers from FootstepsViz instead of recreating
- expose layer constants via layers index for reuse

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a46f6c6bc48323a44b3362c3262a0a