### PR TITLE
refactor: extract reusable toggle button component

### DIFF
--- a/humans-globe/components/ui/TerrainToggle.tsx
+++ b/humans-globe/components/ui/TerrainToggle.tsx
@@ -1,44 +1,33 @@
 'use client';
 
+import ToggleButton, { TOGGLE_CONTAINER_TW } from './ToggleButton';
+
 interface TerrainToggleProps {
   showTerrain: boolean;
   onToggle: (enabled: boolean) => void;
 }
 
-export const TOGGLE_BUTTON_TW =
-  'w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center rounded-full leading-none text-2xl transition-colors duration-200';
-export const TOGGLE_CONTAINER_TW =
-  'inline-flex items-center gap-0 rounded-full bg-gray-700/70 p-0 backdrop-blur-md shadow-lg ring-1 ring-gray-600/40';
-
 export default function TerrainToggle({ showTerrain, onToggle }: TerrainToggleProps) {
   return (
     <div className={TOGGLE_CONTAINER_TW} role="group" aria-label="Background style">
-      <button
+      <ToggleButton
+        pressed={showTerrain}
         onClick={() => onToggle(true)}
-        className={`${TOGGLE_BUTTON_TW}  ${
-          showTerrain
-            ? 'bg-emerald-500 text-white shadow-md'
-            : 'text-gray-200 hover:text-white hover:bg-white/10'
-        }`}
+        label="Terrain"
         title="🏔️ Show terrain imagery"
-        aria-pressed={showTerrain}
-        aria-label="Terrain"
+        activeClassName="bg-emerald-500 text-white shadow-md"
       >
         🏔️
-      </button>
-      <button
+      </ToggleButton>
+      <ToggleButton
+        pressed={!showTerrain}
         onClick={() => onToggle(false)}
-        className={`${TOGGLE_BUTTON_TW} ${
-          !showTerrain
-            ? 'bg-emerald-500 text-white shadow-md'
-            : 'text-gray-200 hover:text-white hover:bg-white/10'
-        }`}
+        label="Plain"
         title="⚫️ Plain background for dot clarity"
-        aria-pressed={!showTerrain}
-        aria-label="Plain"
+        activeClassName="bg-emerald-500 text-white shadow-md"
       >
         ⚫️
-      </button>
+      </ToggleButton>
     </div>
   );
 }

--- a/humans-globe/components/ui/ToggleButton.tsx
+++ b/humans-globe/components/ui/ToggleButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface ToggleButtonProps {
+  pressed: boolean;
+  onClick: () => void;
+  label: string;
+  title?: string;
+  activeClassName: string;
+  children: ReactNode;
+}
+
+export const TOGGLE_CONTAINER_TW =
+  'inline-flex items-center gap-0 rounded-full bg-gray-700/70 p-0 backdrop-blur-md shadow-lg ring-1 ring-gray-600/40';
+
+const BUTTON_TW =
+  'w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center rounded-full leading-none text-2xl transition-colors duration-200';
+
+export default function ToggleButton({
+  pressed,
+  onClick,
+  label,
+  title,
+  activeClassName,
+  children,
+}: ToggleButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`${BUTTON_TW} ${
+        pressed ? activeClassName : 'text-gray-200 hover:text-white hover:bg-white/10'
+      }`}
+      title={title ?? label}
+      aria-pressed={pressed}
+      aria-label={label}
+    >
+      {children}
+    </button>
+  );
+}
+

--- a/humans-globe/components/ui/VizToggles.tsx
+++ b/humans-globe/components/ui/VizToggles.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import TerrainToggle, { TOGGLE_BUTTON_TW, TOGGLE_CONTAINER_TW } from './TerrainToggle';
+import ToggleButton, { TOGGLE_CONTAINER_TW } from './ToggleButton';
+import TerrainToggle from './TerrainToggle';
 
 interface VizTogglesProps {
   showTerrain: boolean;
@@ -21,32 +22,24 @@ export default function VizToggles({
     <div className={className}>
       {/* 2D / 3D view toggle */}
       <div className={TOGGLE_CONTAINER_TW} role="group" aria-label="View mode">
-        <button
+        <ToggleButton
+          pressed={!is3DMode}
           onClick={() => onModeChange(false)}
-          className={`${TOGGLE_BUTTON_TW} ${
-            !is3DMode
-              ? 'bg-blue-500 text-white shadow-md'
-              : 'text-gray-200 hover:text-white hover:bg-white/10'
-          }`}
+          label="Map view"
           title="🗺️ 2D Map view"
-          aria-pressed={!is3DMode}
-          aria-label="Map view"
+          activeClassName="bg-blue-500 text-white shadow-md"
         >
           🗺️
-        </button>
-        <button
+        </ToggleButton>
+        <ToggleButton
+          pressed={is3DMode}
           onClick={() => onModeChange(true)}
-          className={`${TOGGLE_BUTTON_TW} ${
-            is3DMode
-              ? 'bg-blue-500 text-white shadow-md'
-              : 'text-gray-200 hover:text-white hover:bg-white/10'
-          }`}
+          label="Globe view"
           title="🌍 3D Globe view"
-          aria-pressed={is3DMode}
-          aria-label="Globe view"
+          activeClassName="bg-blue-500 text-white shadow-md"
         >
           🌍
-        </button>
+        </ToggleButton>
       </div>
 
       {/* Terrain / Plain toggle */}


### PR DESCRIPTION
## Summary
- create `ToggleButton` with shared tailwind classes and aria props
- refactor `TerrainToggle` and `VizToggles` to use `ToggleButton`
- drop duplicate `TOGGLE_BUTTON_TW` constants

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46f7530688323b79ab14afd095a11