### PR TITLE
refactor: remove legend overlay

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -10,7 +10,6 @@ import {
 import { createHumanLayerFactory } from '@/components/footsteps/layers/humanLayerFactory';
 import { type LayersList } from '@deck.gl/core';
 import SupportingText from '@/components/footsteps/overlays/SupportingText';
-import LegendOverlay from '@/components/footsteps/overlays/LegendOverlay';
 import PopulationTooltip from '@/components/footsteps/overlays/PopulationTooltip';
 import DeckGLView from '@/components/footsteps/views/DeckGLView';
 import useGlobeViewState from '@/components/footsteps/hooks/useGlobeViewState';
@@ -222,9 +221,6 @@ function FootstepsViz({ year }: FootstepsVizProps) {
           onToggle={setShowTerrain}
         />
       </div>
-
-      {/* Legend */}
-      <LegendOverlay />
 
       {/* Population Tooltip */}
       <PopulationTooltip

--- a/humans-globe/components/footsteps/overlays/LegendOverlay.tsx
+++ b/humans-globe/components/footsteps/overlays/LegendOverlay.tsx
@@ -1,6 +1,0 @@
-"use client";
-
-export default function LegendOverlay() {
-  // Legend overlay removed as per user request
-  return null;
-}


### PR DESCRIPTION
## Summary
- remove unused `LegendOverlay` component and references from `FootstepsViz`

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a46f8190b4832383ebf98dba322572