### PR TITLE
refactor: centralize population scale helper

### DIFF
--- a/humans-globe/components/footsteps/overlays/PopulationTooltip.tsx
+++ b/humans-globe/components/footsteps/overlays/PopulationTooltip.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
-import {
-  getTooltipPosition,
-  getPopulationScale,
-  formatCoordinates,
-} from './tooltipUtils';
+import { getTooltipPosition, formatCoordinates } from './tooltipUtils';
+import { getPopulationScale } from '@/lib/format';
 
 interface TooltipData {
   population: number;

--- a/humans-globe/components/footsteps/overlays/tooltipUtils.test.ts
+++ b/humans-globe/components/footsteps/overlays/tooltipUtils.test.ts
@@ -1,8 +1,5 @@
-import {
-  getTooltipPosition,
-  getPopulationScale,
-  formatCoordinates,
-} from './tooltipUtils';
+import { getTooltipPosition, formatCoordinates } from './tooltipUtils';
+import { getPopulationScale } from '@/lib/format';
 
 describe('getTooltipPosition', () => {
   it('positions tooltip to the left when near the right edge', () => {

--- a/humans-globe/components/footsteps/overlays/tooltipUtils.ts
+++ b/humans-globe/components/footsteps/overlays/tooltipUtils.ts
@@ -36,40 +36,6 @@ export function getTooltipPosition(
 
   return { left, top };
 }
-
-export function getPopulationScale(population: number): {
-  scale: string;
-  icon: string;
-  significance: string;
-} {
-  if (population > 1000000) {
-    return {
-      scale: 'Megacity',
-      icon: '🏙️',
-      significance: 'Major urban center',
-    };
-  }
-  if (population > 500000) {
-    return { scale: 'Metropolis', icon: '🌆', significance: 'Large city' };
-  }
-  if (population > 100000) {
-    return { scale: 'City', icon: '🏘️', significance: 'Urban settlement' };
-  }
-  if (population > 50000) {
-    return { scale: 'Large Town', icon: '🏘️', significance: 'Regional center' };
-  }
-  if (population > 10000) {
-    return { scale: 'Town', icon: '🏘️', significance: 'Local hub' };
-  }
-  if (population > 2000) {
-    return { scale: 'Village', icon: '🏠', significance: 'Rural community' };
-  }
-  if (population > 500) {
-    return { scale: 'Hamlet', icon: '🏡', significance: 'Small settlement' };
-  }
-  return { scale: 'Outpost', icon: '⛺', significance: 'Remote presence' };
-}
-
 export function formatCoordinates(coords: [number, number]): string {
   const [lon, lat] = coords;
   const latDir = lat >= 0 ? 'N' : 'S';

--- a/humans-globe/lib/format.ts
+++ b/humans-globe/lib/format.ts
@@ -11,6 +11,41 @@ export function formatPopulation(pop: number): string {
   return `${Math.round(pop).toLocaleString()} people`;
 }
 
+// Translate population counts into a qualitative scale.
+// Used by overlays and will support future charts.
+export function getPopulationScale(population: number): {
+  scale: string;
+  icon: string;
+  significance: string;
+} {
+  if (population > 1_000_000) {
+    return {
+      scale: 'Megacity',
+      icon: '🏙️',
+      significance: 'Major urban center',
+    };
+  }
+  if (population > 500_000) {
+    return { scale: 'Metropolis', icon: '🌆', significance: 'Large city' };
+  }
+  if (population > 100_000) {
+    return { scale: 'City', icon: '🏘️', significance: 'Urban settlement' };
+  }
+  if (population > 50_000) {
+    return { scale: 'Large Town', icon: '🏘️', significance: 'Regional center' };
+  }
+  if (population > 10_000) {
+    return { scale: 'Town', icon: '🏘️', significance: 'Local hub' };
+  }
+  if (population > 2_000) {
+    return { scale: 'Village', icon: '🏠', significance: 'Rural community' };
+  }
+  if (population > 500) {
+    return { scale: 'Hamlet', icon: '🏡', significance: 'Small settlement' };
+  }
+  return { scale: 'Outpost', icon: '⛺', significance: 'Remote presence' };
+}
+
 // Describe the level of detail based on zoom level
 export function getDetailContext(zoom: number): string {
   if (zoom < 4) return 'Regional clusters • Showing major population centers';


### PR DESCRIPTION
## Summary
- move `getPopulationScale` to shared `lib/format` helper
- update `PopulationTooltip` and tests to pull scale from new location

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a46f9f923883238daa2eb668546427