### PR TITLE
refactor: centralize globe view thresholds

### DIFF
--- a/humans-globe/components/footsteps/hooks/useGlobeViewState.ts
+++ b/humans-globe/components/footsteps/hooks/useGlobeViewState.ts
@@ -2,6 +2,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useDebouncedFlag from '@/components/footsteps/hooks/useDebouncedFlag';
 
+// Thresholds centralized for easy tweaking; small changes below these values
+// come from deck.gl's internal updates and shouldn't trigger interaction flags.
+const ZOOM_DELTA_THRESHOLD = 0.01;
+const PAN_THRESHOLD = 0.1;
+
 type BasicViewState = {
   longitude: number;
   latitude: number;
@@ -79,15 +84,13 @@ export default function useGlobeViewState() {
 
       if (
         typeof normalized.zoom === 'number' &&
-        Math.abs(normalized.zoom - oldState.zoom) > 0.01
+        Math.abs(normalized.zoom - oldState.zoom) > ZOOM_DELTA_THRESHOLD
       ) {
         triggerZoom();
       }
-
-      const panThreshold = 0.1;
       if (
-        (Math.abs(normalized.longitude - oldState.longitude) > panThreshold ||
-          Math.abs(normalized.latitude - oldState.latitude) > panThreshold) &&
+        (Math.abs(normalized.longitude - oldState.longitude) > PAN_THRESHOLD ||
+          Math.abs(normalized.latitude - oldState.latitude) > PAN_THRESHOLD) &&
         !isZoomingRef.current
       ) {
         triggerPan();


### PR DESCRIPTION
## Summary
- centralize pan and zoom thresholds in `useGlobeViewState`
- reference constants instead of magic numbers

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46fa69ccc8323a2ef0dae4d77e47a