### PR TITLE
refactor: modularize layer helpers

### DIFF
--- a/humans-globe/components/footsteps/FootstepsViz.tsx
+++ b/humans-globe/components/footsteps/FootstepsViz.tsx
@@ -96,11 +96,15 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         isYearCrossfading,
         newLayerReadyRef,
         newLayerHasTileRef,
-        startCrossfade,
-        setTileLoading,
-        setFeatureCount,
-        setTotalPopulation,
-        setTooltipData,
+        callbacks: {
+          startCrossfade,
+          setTileLoading,
+          setTooltipData,
+        },
+        metrics: {
+          setFeatureCount,
+          setTotalPopulation,
+        },
       }),
     [
       is3DMode,

--- a/humans-globe/components/footsteps/layers/crossfade.test.ts
+++ b/humans-globe/components/footsteps/layers/crossfade.test.ts
@@ -1,0 +1,39 @@
+import type { MutableRefObject } from 'react';
+import { computeFadeMs, handleTileLoad, triggerCrossfade } from './crossfade';
+import { NEW_YEAR_FADE_MS, YEAR_FADE_MS } from '../hooks/useYearCrossfade';
+
+describe('crossfade helpers', () => {
+  it('computes fade duration based on state', () => {
+    const ref = { current: true } as MutableRefObject<boolean>;
+    expect(computeFadeMs(true, ref)).toBe(NEW_YEAR_FADE_MS);
+    expect(computeFadeMs(false, ref)).toBe(YEAR_FADE_MS);
+    ref.current = false;
+    expect(computeFadeMs(true, ref)).toBe(0);
+  });
+
+  it('handles tile load state', () => {
+    const hasTileRef = { current: false } as MutableRefObject<boolean>;
+    let loading = true;
+    const setTileLoading = (l: boolean) => {
+      loading = l;
+    };
+    handleTileLoad(true, hasTileRef, setTileLoading);
+    expect(loading).toBe(false);
+    expect(hasTileRef.current).toBe(true);
+  });
+
+  it('triggers crossfade', () => {
+    let loading = true;
+    let crossfaded = false;
+    triggerCrossfade(
+      (l) => {
+        loading = l;
+      },
+      () => {
+        crossfaded = true;
+      },
+    );
+    expect(loading).toBe(false);
+    expect(crossfaded).toBe(true);
+  });
+});

--- a/humans-globe/components/footsteps/layers/crossfade.ts
+++ b/humans-globe/components/footsteps/layers/crossfade.ts
@@ -1,0 +1,34 @@
+import type { MutableRefObject } from 'react';
+import { NEW_YEAR_FADE_MS, YEAR_FADE_MS } from '../hooks/useYearCrossfade';
+
+export function computeFadeMs(
+  isNewYearLayer: boolean,
+  newLayerReadyRef: MutableRefObject<boolean>,
+) {
+  return newLayerReadyRef.current
+    ? isNewYearLayer
+      ? NEW_YEAR_FADE_MS
+      : YEAR_FADE_MS
+    : 0;
+}
+
+export function handleTileLoad(
+  isNewYearLayer: boolean,
+  newLayerHasTileRef: MutableRefObject<boolean>,
+  setTileLoading: (loading: boolean) => void,
+) {
+  if (isNewYearLayer) {
+    setTileLoading(false);
+    if (!newLayerHasTileRef.current) {
+      newLayerHasTileRef.current = true;
+    }
+  }
+}
+
+export function triggerCrossfade(
+  setTileLoading: (loading: boolean) => void,
+  startCrossfade: () => void,
+) {
+  setTileLoading(false);
+  startCrossfade();
+}

--- a/humans-globe/components/footsteps/layers/humanLayerFactory.ts
+++ b/humans-globe/components/footsteps/layers/humanLayerFactory.ts
@@ -1,78 +1,12 @@
 import type { MutableRefObject } from 'react';
 import { createHumanTilesLayer, radiusStrategies } from './index';
-import { NEW_YEAR_FADE_MS, YEAR_FADE_MS } from '../hooks/useYearCrossfade';
+import { buildTooltipData, type PickingInfo } from './tooltip';
+import { aggregateTileMetrics } from './tileMetrics';
+import { computeFadeMs, handleTileLoad, triggerCrossfade } from './crossfade';
 
-interface PickingInfo {
-  object?: {
-    properties?: { population?: number };
-    geometry?: { coordinates?: [number, number] };
-  };
-  x?: number;
-  y?: number;
-}
-
-function buildTooltipData(info: PickingInfo, year: number) {
-  if (info?.object) {
-    const f = info.object as {
-      properties?: { population?: number };
-      geometry?: { coordinates?: [number, number] };
-    };
-    const population = f?.properties?.population || 0;
-    const coordinates = (f?.geometry?.coordinates as [number, number]) || [
-      0, 0,
-    ];
-    const clickPosition = { x: info.x || 0, y: info.y || 0 };
-    return { population, coordinates, year, clickPosition };
-  }
-  return null;
-}
-
-function featuresFromTile(
-  tile: unknown,
-): Array<{ properties?: { population?: number } }> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const t = tile as any;
-    const tileCoords = t?.index
-      ? `${t.index.z}/${t.index.x}/${t.index.y}`
-      : 'unknown';
-    void tileCoords; // quiet unused in production
-    const possibleFeatures = [
-      t?.data?.features,
-      t?.content?.features,
-      t?.data,
-      t?.content,
-      t?.data?.layers?.['humans']?.features,
-      t?.content?.layers?.['humans']?.features,
-      Array.isArray(t?.data) ? t.data : null,
-      Array.isArray(t?.content) ? t.content : null,
-    ].filter(Boolean);
-
-    for (let i = 0; i < possibleFeatures.length; i++) {
-      const candidate = possibleFeatures[i];
-      if (Array.isArray(candidate) && candidate.length > 0) {
-        return candidate;
-      }
-    }
-    return [];
-  } catch (error) {
-    console.error(`[FEATURE-EXTRACT-ERROR]:`, error);
-    return [];
-  }
-}
-
-interface HumanLayerFactoryOptions {
-  is3DMode: boolean;
-  layerViewState: { zoom?: number } | null;
-  isZooming: boolean;
-  isPanning: boolean;
-  isYearCrossfading: boolean;
-  newLayerReadyRef: MutableRefObject<boolean>;
-  newLayerHasTileRef: MutableRefObject<boolean>;
+export interface HumanLayerCallbacks {
   startCrossfade: () => void;
   setTileLoading: (loading: boolean) => void;
-  setFeatureCount: (count: number) => void;
-  setTotalPopulation: (total: number) => void;
   setTooltipData: (
     data: {
       population: number;
@@ -84,7 +18,24 @@ interface HumanLayerFactoryOptions {
   ) => void;
 }
 
-export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
+export interface HumanLayerMetrics {
+  setFeatureCount: (count: number) => void;
+  setTotalPopulation: (total: number) => void;
+}
+
+export interface HumanLayerFactoryConfig {
+  is3DMode: boolean;
+  layerViewState: { zoom?: number } | null;
+  isZooming: boolean;
+  isPanning: boolean;
+  isYearCrossfading: boolean;
+  newLayerReadyRef: MutableRefObject<boolean>;
+  newLayerHasTileRef: MutableRefObject<boolean>;
+  callbacks: HumanLayerCallbacks;
+  metrics: HumanLayerMetrics;
+}
+
+export function createHumanLayerFactory(config: HumanLayerFactoryConfig) {
   const {
     is3DMode,
     layerViewState,
@@ -93,12 +44,9 @@ export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
     isYearCrossfading,
     newLayerReadyRef,
     newLayerHasTileRef,
-    startCrossfade,
-    setTileLoading,
-    setFeatureCount,
-    setTotalPopulation,
-    setTooltipData,
-  } = options;
+    callbacks,
+    metrics,
+  } = config;
 
   return function createHumanLayerForYear(
     targetYear: number,
@@ -111,11 +59,7 @@ export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
       ? radiusStrategies.globe3D
       : radiusStrategies.zoomAdaptive;
 
-    const fadeMs = newLayerReadyRef.current
-      ? isNewYearLayer
-        ? NEW_YEAR_FADE_MS
-        : YEAR_FADE_MS
-      : 0;
+    const fadeMs = computeFadeMs(isNewYearLayer, newLayerReadyRef);
 
     return createHumanTilesLayer(
       targetYear,
@@ -125,44 +69,37 @@ export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
       (raw: unknown) => {
         const info = raw as PickingInfo;
         const data = buildTooltipData(info, targetYear);
-        if (data) setTooltipData(data);
+        if (data) callbacks.setTooltipData(data);
       },
       (raw: unknown) => {
         const info = raw as PickingInfo;
-        setTooltipData(buildTooltipData(info, targetYear));
+        callbacks.setTooltipData(buildTooltipData(info, targetYear));
       },
       {
         onTileLoad: (_tile: unknown) => {
-          if (isNewYearLayer) {
-            setTileLoading(false);
-            if (!newLayerHasTileRef.current) {
-              newLayerHasTileRef.current = true;
-            }
-          }
+          handleTileLoad(
+            isNewYearLayer,
+            newLayerHasTileRef,
+            callbacks.setTileLoading,
+          );
         },
         onViewportLoad: (rawTiles: unknown[]) => {
           try {
             if (isNewYearLayer) {
-              const tiles = rawTiles as Array<unknown>;
-              let count = 0;
-              let pop = 0;
-              for (const t of tiles) {
-                const feats = featuresFromTile(t);
-                count += feats.length;
-                for (const g of feats)
-                  pop += Number(g?.properties?.population) || 0;
-              }
-              setFeatureCount(count);
-              setTotalPopulation(pop);
-              setTileLoading(false);
-              startCrossfade();
+              const metricsResult = aggregateTileMetrics(rawTiles);
+              metrics.setFeatureCount(metricsResult.count);
+              metrics.setTotalPopulation(metricsResult.population);
+              triggerCrossfade(
+                callbacks.setTileLoading,
+                callbacks.startCrossfade,
+              );
             }
           } catch (error) {
             console.error(
               `[VIEWPORT-LOAD-ERROR] Year: ${targetYear}, LOD: ${lodLevel}:`,
               error,
             );
-            setTileLoading(false);
+            callbacks.setTileLoading(false);
           }
         },
         onTileError: (error: unknown) => {
@@ -180,7 +117,7 @@ export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
             status,
             error: errorInfo?.message || errorInfo?.error || errorInfo,
           });
-          setTileLoading(false);
+          callbacks.setTileLoading(false);
         },
         tileOptions: {
           fadeMs: fadeMs,
@@ -200,5 +137,3 @@ export function createHumanLayerFactory(options: HumanLayerFactoryOptions) {
     );
   };
 }
-
-export { buildTooltipData };

--- a/humans-globe/components/footsteps/layers/tileMetrics.test.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.test.ts
@@ -1,0 +1,24 @@
+import { featuresFromTile, aggregateTileMetrics } from './tileMetrics';
+
+describe('tile metrics helpers', () => {
+  it('extracts features from nested tile structures', () => {
+    const tile = { data: { features: [{ properties: { population: 1 } }] } };
+    expect(featuresFromTile(tile)).toHaveLength(1);
+  });
+
+  it('aggregates count and population across tiles', () => {
+    const tiles = [
+      {
+        data: {
+          features: [
+            { properties: { population: 2 } },
+            { properties: { population: 3 } },
+          ],
+        },
+      },
+      { content: { features: [{ properties: { population: 5 } }] } },
+    ];
+    const result = aggregateTileMetrics(tiles);
+    expect(result).toEqual({ count: 3, population: 10 });
+  });
+});

--- a/humans-globe/components/footsteps/layers/tileMetrics.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.ts
@@ -1,0 +1,48 @@
+export interface Feature {
+  properties?: { population?: number };
+}
+
+export function featuresFromTile(tile: unknown): Feature[] {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = tile as any;
+    const tileCoords = t?.index
+      ? `${t.index.z}/${t.index.x}/${t.index.y}`
+      : 'unknown';
+    void tileCoords;
+    const possibleFeatures = [
+      t?.data?.features,
+      t?.content?.features,
+      t?.data,
+      t?.content,
+      t?.data?.layers?.['humans']?.features,
+      t?.content?.layers?.['humans']?.features,
+      Array.isArray(t?.data) ? t.data : null,
+      Array.isArray(t?.content) ? t.content : null,
+    ].filter(Boolean);
+
+    for (let i = 0; i < possibleFeatures.length; i++) {
+      const candidate = possibleFeatures[i];
+      if (Array.isArray(candidate) && candidate.length > 0) {
+        return candidate as Feature[];
+      }
+    }
+    return [];
+  } catch (error) {
+    console.error(`[FEATURE-EXTRACT-ERROR]:`, error);
+    return [];
+  }
+}
+
+export function aggregateTileMetrics(tiles: unknown[]) {
+  let count = 0;
+  let population = 0;
+  for (const t of tiles) {
+    const feats = featuresFromTile(t);
+    count += feats.length;
+    for (const g of feats) {
+      population += Number(g?.properties?.population) || 0;
+    }
+  }
+  return { count, population };
+}

--- a/humans-globe/components/footsteps/layers/tooltip.test.ts
+++ b/humans-globe/components/footsteps/layers/tooltip.test.ts
@@ -1,0 +1,26 @@
+import { buildTooltipData, type PickingInfo } from './tooltip';
+
+describe('buildTooltipData', () => {
+  it('returns tooltip data when object exists', () => {
+    const info: PickingInfo = {
+      object: {
+        properties: { population: 123 },
+        geometry: { coordinates: [1, 2] },
+      },
+      x: 10,
+      y: 20,
+    };
+    const result = buildTooltipData(info, 1500);
+    expect(result).toEqual({
+      population: 123,
+      coordinates: [1, 2],
+      year: 1500,
+      clickPosition: { x: 10, y: 20 },
+    });
+  });
+
+  it('returns null when no object', () => {
+    const info: PickingInfo = { x: 1, y: 2 };
+    expect(buildTooltipData(info, 1500)).toBeNull();
+  });
+});

--- a/humans-globe/components/footsteps/layers/tooltip.ts
+++ b/humans-globe/components/footsteps/layers/tooltip.ts
@@ -1,0 +1,24 @@
+export interface PickingInfo {
+  object?: {
+    properties?: { population?: number };
+    geometry?: { coordinates?: [number, number] };
+  };
+  x?: number;
+  y?: number;
+}
+
+export function buildTooltipData(info: PickingInfo, year: number) {
+  if (info?.object) {
+    const f = info.object as {
+      properties?: { population?: number };
+      geometry?: { coordinates?: [number, number] };
+    };
+    const population = f?.properties?.population || 0;
+    const coordinates = (f?.geometry?.coordinates as [number, number]) || [
+      0, 0,
+    ];
+    const clickPosition = { x: info.x || 0, y: info.y || 0 };
+    return { population, coordinates, year, clickPosition };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- split tooltip, tile metric, and crossfade helpers into dedicated modules
- redesign human layer factory to use structured callbacks and metrics config
- add unit tests for new helpers

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a46e6ac7e88323ac5f29031dfd0c5f