### PR TITLE
fix: defer crossfade until tile loads

### DIFF
--- a/humans-globe/components/footsteps/layers/crossfade.test.ts
+++ b/humans-globe/components/footsteps/layers/crossfade.test.ts
@@ -23,9 +23,11 @@ describe('crossfade helpers', () => {
   });
 
   it('triggers crossfade', () => {
+    const hasTileRef = { current: true } as MutableRefObject<boolean>;
     let loading = true;
     let crossfaded = false;
     triggerCrossfade(
+      hasTileRef,
       (l) => {
         loading = l;
       },
@@ -33,6 +35,42 @@ describe('crossfade helpers', () => {
         crossfaded = true;
       },
     );
+    expect(loading).toBe(false);
+    expect(crossfaded).toBe(true);
+  });
+
+  it('defers crossfade until a tile is loaded', () => {
+    const hasTileRef = { current: false } as MutableRefObject<boolean>;
+    let loading = true;
+    let crossfaded = false;
+
+    triggerCrossfade(
+      hasTileRef,
+      (l) => {
+        loading = l;
+      },
+      () => {
+        crossfaded = true;
+      },
+    );
+
+    expect(loading).toBe(true);
+    expect(crossfaded).toBe(false);
+
+    handleTileLoad(true, hasTileRef, (l) => {
+      loading = l;
+    });
+
+    triggerCrossfade(
+      hasTileRef,
+      (l) => {
+        loading = l;
+      },
+      () => {
+        crossfaded = true;
+      },
+    );
+
     expect(loading).toBe(false);
     expect(crossfaded).toBe(true);
   });

--- a/humans-globe/components/footsteps/layers/crossfade.ts
+++ b/humans-globe/components/footsteps/layers/crossfade.ts
@@ -26,9 +26,13 @@ export function handleTileLoad(
 }
 
 export function triggerCrossfade(
+  newLayerHasTileRef: MutableRefObject<boolean>,
   setTileLoading: (loading: boolean) => void,
   startCrossfade: () => void,
 ) {
+  if (!newLayerHasTileRef.current) {
+    return;
+  }
   setTileLoading(false);
   startCrossfade();
 }

--- a/humans-globe/components/footsteps/layers/humanLayer.ts
+++ b/humans-globe/components/footsteps/layers/humanLayer.ts
@@ -225,6 +225,7 @@ export function createHumanLayerFactory(config: HumanLayerFactoryConfig) {
               metrics.setFeatureCount(metricsResult.count);
               metrics.setTotalPopulation(metricsResult.population);
               triggerCrossfade(
+                newLayerHasTileRef,
                 callbacks.setTileLoading,
                 callbacks.startCrossfade,
               );


### PR DESCRIPTION
## Summary
- avoid crossfade when new layer has no loaded tiles
- pass tile-loaded ref from human layer and add regression test

## Testing
- `pnpm lint`
- `pnpm exec prettier components/footsteps/layers/crossfade.ts components/footsteps/layers/humanLayer.ts components/footsteps/layers/crossfade.test.ts --write`
- `pnpm test`
- `poetry run black --check footstep-generator` *(fails: would reformat 31 files)*
- `poetry run isort --check footstep-generator` *(fails: imports not sorted)*
- `poetry run pytest footstep-generator -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a47cf40d20832399f1bf891b06a8fe