### PR TITLE
fix: unify tiles bucket env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Open `http://localhost:4444` in your browser.
 
 * __Environment__
   - Dev/local: tiles resolved from `HUMANS_TILES_DIR` (default: `../data/tiles/humans` relative to `humans-globe/` runtime).
-  - Prod/GCS: set `NODE_ENV=production`, `GCP_PROJECT_ID`, `GCS_BUCKET_NAME` to serve from Google Cloud Storage.
+  - Prod/GCS: set `NODE_ENV=production`, `GCP_PROJECT_ID`, `GCS_TILES_BUCKET` to serve from Google Cloud Storage.
   - Tile cache dir (GCS only): `TILE_CACHE_DIR` (default `/tmp/humans-tiles-cache`) for downloaded `.mbtiles` reuse.
 
 * __Caching__
@@ -228,7 +228,7 @@ pnpm start
 
 ### Tiles in Production
 - Local files: set `HUMANS_TILES_DIR=/path/to/data/tiles/humans` in the runtime env
-- GCS hosting (optional): set `NODE_ENV=production`, `GCP_PROJECT_ID`, and `GCS_BUCKET_NAME` to stream tiles from GCS
+- GCS hosting (optional): set `NODE_ENV=production`, `GCP_PROJECT_ID`, and `GCS_TILES_BUCKET` to stream tiles from GCS
 - Optional cache dir for GCS downloads: `TILE_CACHE_DIR` (default `/tmp/humans-tiles-cache`)
 
 

--- a/humans-globe/lib/tilesService.test.ts
+++ b/humans-globe/lib/tilesService.test.ts
@@ -1,0 +1,19 @@
+import { getTilesBucket } from './tilesService';
+
+describe('getTilesBucket', () => {
+  const origEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    jest.restoreAllMocks();
+  });
+
+  it('throws with clear error when missing', () => {
+    delete process.env.GCS_TILES_BUCKET;
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => getTilesBucket()).toThrow(
+      'GCS_TILES_BUCKET environment variable is required',
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -143,11 +143,6 @@ resource "google_cloud_run_v2_service" "app" {
         value = var.project_id
       }
 
-      env {
-        name  = "GCS_BUCKET_NAME"
-        value = google_storage_bucket.data_bucket.name
-      }
-
       # Tiles redirection config for API
       env {
         name  = "GCS_TILES_BUCKET"

--- a/iac/scripts/deploy.sh
+++ b/iac/scripts/deploy.sh
@@ -87,7 +87,7 @@ fi
 # Deploy to Cloud Run
 echo "🚀 Deploying to Cloud Run..."
 ## Build env vars for the service (runtime only)
-ENV_VARS="NODE_ENV=production,GCP_PROJECT_ID=$PROJECT_ID,GCS_BUCKET_NAME=footsteps-earth-tiles,HUMANS_TILES_DIR=/data/tiles/humans,TILE_CACHE_DIR=/data/tiles/humans"
+ENV_VARS="NODE_ENV=production,GCP_PROJECT_ID=$PROJECT_ID,GCS_TILES_BUCKET=footsteps-earth-tiles,HUMANS_TILES_DIR=/data/tiles/humans,TILE_CACHE_DIR=/data/tiles/humans"
 
 gcloud run deploy "$SERVICE_NAME" \
     --image "$IMAGE_NAME" \


### PR DESCRIPTION
## Summary
- standardize on `GCS_TILES_BUCKET` for tile storage
- document new environment variable and deployment settings
- add runtime check and test for missing tile bucket config

## Testing
- `pnpm lint`
- `npx prettier humans-globe/lib/tilesService.ts humans-globe/app/api/admin/warm-cache/route.ts humans-globe/lib/tilesService.test.ts -w`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a47d1e367883238a4cdaf562f992da