### PR TITLE
fix: throttle window width updates

### DIFF
--- a/humans-globe/components/ui/hooks/useSliderMarks.test.tsx
+++ b/humans-globe/components/ui/hooks/useSliderMarks.test.tsx
@@ -8,7 +8,7 @@ function TestComponent({ value }: { value: number }) {
   return <div data-testid="marks">{JSON.stringify(marks)}</div>;
 }
 
-function getMarksForWidth(width: number) {
+async function getMarksForWidth(width: number) {
   Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -16,8 +16,9 @@ function getMarksForWidth(width: number) {
   });
   const sliderVal = yearToSlider(0);
   const { getByTestId } = render(<TestComponent value={sliderVal} />);
-  act(() => {
+  await act(async () => {
     window.dispatchEvent(new Event('resize'));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
   });
   const marks = JSON.parse(getByTestId('marks').textContent as string);
   cleanup();
@@ -27,8 +28,8 @@ function getMarksForWidth(width: number) {
 describe('useSliderMarks', () => {
   const widths = [320, 768, 1024];
   widths.forEach((width) => {
-    test(`ensures minimum spacing at width ${width}px`, () => {
-      const marks = getMarksForWidth(width);
+    test(`ensures minimum spacing at width ${width}px`, async () => {
+      const marks = await getMarksForWidth(width);
       const positions = Object.keys(marks)
         .map(Number)
         .sort((a, b) => a - b);
@@ -41,9 +42,9 @@ describe('useSliderMarks', () => {
     });
   });
 
-  test('renders more marks on wide viewports', () => {
-    const small = getMarksForWidth(320);
-    const large = getMarksForWidth(1280);
+  test('renders more marks on wide viewports', async () => {
+    const small = await getMarksForWidth(320);
+    const large = await getMarksForWidth(1280);
     expect(Object.keys(large).length).toBeGreaterThan(
       Object.keys(small).length,
     );

--- a/humans-globe/components/ui/hooks/useWindowWidth.ts
+++ b/humans-globe/components/ui/hooks/useWindowWidth.ts
@@ -8,9 +8,22 @@ export default function useWindowWidth() {
   const [width, setWidth] = useState<number>(1024);
 
   useEffect(() => {
-    const handleResize = () => setWidth(window.innerWidth);
+    let frameId: number | null = null;
+
+    const handleResize = () => {
+      if (frameId !== null) cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        setWidth(window.innerWidth);
+        frameId = null;
+      });
+    };
+
+    handleResize();
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
   }, []);
 
   return width;


### PR DESCRIPTION
## Summary
- avoid rapid state churn in `useWindowWidth` by scheduling resize updates with `requestAnimationFrame`
- ensure cleanup cancels any pending frame
- update `useSliderMarks` tests to wait for the async resize update

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a47ed9d0f4832390d92b77d9ebc7cd