### PR TITLE
feat: offload tile metrics to worker

### DIFF
--- a/humans-globe/components/footsteps/layers/humanLayer.ts
+++ b/humans-globe/components/footsteps/layers/humanLayer.ts
@@ -7,7 +7,13 @@ import { createLayerId, createOnTileLoadHandler } from './tileCache';
 import { getFillColor } from './color';
 import { buildTooltipData, type PickingInfo } from './tooltip';
 import { aggregateTileMetrics } from './tileMetrics';
+import type { TileMetrics } from './tileMetrics';
 import { computeFadeMs, handleTileLoad, triggerCrossfade } from './crossfade';
+
+const tileMetricsWorker: Worker | null =
+  typeof window !== 'undefined'
+    ? new Worker(new URL('./tileMetrics.worker.ts', import.meta.url))
+    : null;
 
 // Create MVT-based human tiles layer
 export function createHumanTilesLayer(
@@ -221,13 +227,28 @@ export function createHumanLayerFactory(config: HumanLayerFactoryConfig) {
         onViewportLoad: (rawTiles: unknown[]) => {
           try {
             if (isNewYearLayer) {
-              const metricsResult = aggregateTileMetrics(rawTiles);
-              metrics.setFeatureCount(metricsResult.count);
-              metrics.setTotalPopulation(metricsResult.population);
-              triggerCrossfade(
-                callbacks.setTileLoading,
-                callbacks.startCrossfade,
-              );
+              if (tileMetricsWorker) {
+                tileMetricsWorker.onmessage = (
+                  e: MessageEvent<TileMetrics>,
+                ) => {
+                  const { count, population } = e.data;
+                  metrics.setFeatureCount(count);
+                  metrics.setTotalPopulation(population);
+                  triggerCrossfade(
+                    callbacks.setTileLoading,
+                    callbacks.startCrossfade,
+                  );
+                };
+                tileMetricsWorker.postMessage(rawTiles);
+              } else {
+                const metricsResult = aggregateTileMetrics(rawTiles);
+                metrics.setFeatureCount(metricsResult.count);
+                metrics.setTotalPopulation(metricsResult.population);
+                triggerCrossfade(
+                  callbacks.setTileLoading,
+                  callbacks.startCrossfade,
+                );
+              }
             }
           } catch (error) {
             console.error(

--- a/humans-globe/components/footsteps/layers/tileMetrics.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.ts
@@ -2,6 +2,11 @@ export interface Feature {
   properties?: { population?: number };
 }
 
+export interface TileMetrics {
+  count: number;
+  population: number;
+}
+
 export function featuresFromTile(tile: unknown): Feature[] {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,7 +39,7 @@ export function featuresFromTile(tile: unknown): Feature[] {
   }
 }
 
-export function aggregateTileMetrics(tiles: unknown[]) {
+export function aggregateTileMetrics(tiles: unknown[]): TileMetrics {
   let count = 0;
   let population = 0;
   for (const t of tiles) {

--- a/humans-globe/components/footsteps/layers/tileMetrics.worker.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.worker.ts
@@ -1,0 +1,17 @@
+import { aggregateTileMetrics } from './tileMetrics';
+import type { TileMetrics } from './tileMetrics';
+
+const ctx: DedicatedWorkerGlobalScope =
+  self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = (event: MessageEvent<unknown[]>) => {
+  try {
+    const result: TileMetrics = aggregateTileMetrics(event.data);
+    ctx.postMessage(result);
+  } catch (error) {
+    console.error('[TILE-METRICS-WORKER-ERROR]:', error);
+    ctx.postMessage({ count: 0, population: 0 });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- process tile metrics in a web worker to keep rendering responsive
- send tile data to worker in `onViewportLoad` and update metrics from worker messages

## Testing
- `pnpm lint`
- `pnpm prettier components/footsteps/layers/tileMetrics.ts components/footsteps/layers/humanLayer.ts components/footsteps/layers/tileMetrics.worker.ts --write`
- `pnpm test`
- `poetry run black footstep-generator --check` *(fails: would reformat 31 files)*
- `poetry run isort footstep-generator --check-only` *(fails: imports incorrectly sorted)*
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a47eea3dd48323926e9a5191bf47ce