### PR TITLE
feat: switch human layer to binary tiles

### DIFF
--- a/humans-globe/components/footsteps/layers/humanLayer.ts
+++ b/humans-globe/components/footsteps/layers/humanLayer.ts
@@ -67,13 +67,12 @@ export function createHumanTilesLayer(
     maxRequests: tileOptions.maxRequests ?? 6,
     zoomOffset: tileOptions.zoomOffset ?? 0,
     autoHighlight: false,
-    // Use GeoJSON for easier debugging
-    binary: false,
+    // Use binary tiles for performance
+    binary: true,
     // Simplified load options
     loadOptions: {
       mvt: {
         coordinates: 'wgs84',
-        shape: 'geojson',
         // Single-layer yearly MBTiles exports features under the 'humans' layer
         layers: ['humans'],
       },
@@ -257,7 +256,7 @@ export function createHumanLayerFactory(config: HumanLayerFactoryConfig) {
         tileOptions: {
           fadeMs: fadeMs,
           debounceTime: isZooming || isPanning ? 80 : 20,
-          useBinary: false,
+          useBinary: true,
         },
         debugTint:
           process.env.NODE_ENV !== 'production' && isYearCrossfading

--- a/humans-globe/components/footsteps/layers/tileMetrics.test.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.test.ts
@@ -2,7 +2,17 @@ import { featuresFromTile, aggregateTileMetrics } from './tileMetrics';
 
 describe('tile metrics helpers', () => {
   it('extracts features from nested tile structures', () => {
-    const tile = { data: { features: [{ properties: { population: 1 } }] } };
+    const tile = {
+      data: {
+        layers: {
+          humans: {
+            length: 1,
+            positions: new Float32Array([0, 0]),
+            properties: [{ population: 1 }],
+          },
+        },
+      },
+    };
     expect(featuresFromTile(tile)).toHaveLength(1);
   });
 
@@ -10,13 +20,26 @@ describe('tile metrics helpers', () => {
     const tiles = [
       {
         data: {
-          features: [
-            { properties: { population: 2 } },
-            { properties: { population: 3 } },
-          ],
+          layers: {
+            humans: {
+              length: 2,
+              positions: new Float32Array([0, 0, 1, 1]),
+              properties: [{ population: 2 }, { population: 3 }],
+            },
+          },
         },
       },
-      { content: { features: [{ properties: { population: 5 } }] } },
+      {
+        data: {
+          layers: {
+            humans: {
+              length: 1,
+              positions: new Float32Array([2, 2]),
+              properties: [{ population: 5 }],
+            },
+          },
+        },
+      },
     ];
     const result = aggregateTileMetrics(tiles);
     expect(result).toEqual({ count: 3, population: 10 });

--- a/humans-globe/components/footsteps/layers/tileMetrics.ts
+++ b/humans-globe/components/footsteps/layers/tileMetrics.ts
@@ -1,37 +1,12 @@
-export interface Feature {
-  properties?: { population?: number };
-}
+import {
+  extractFeaturesFromBinaryTile,
+  type Feature,
+} from '@/lib/binaryTileUtils';
+
+export { type Feature };
 
 export function featuresFromTile(tile: unknown): Feature[] {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const t = tile as any;
-    const tileCoords = t?.index
-      ? `${t.index.z}/${t.index.x}/${t.index.y}`
-      : 'unknown';
-    void tileCoords;
-    const possibleFeatures = [
-      t?.data?.features,
-      t?.content?.features,
-      t?.data,
-      t?.content,
-      t?.data?.layers?.['humans']?.features,
-      t?.content?.layers?.['humans']?.features,
-      Array.isArray(t?.data) ? t.data : null,
-      Array.isArray(t?.content) ? t.content : null,
-    ].filter(Boolean);
-
-    for (let i = 0; i < possibleFeatures.length; i++) {
-      const candidate = possibleFeatures[i];
-      if (Array.isArray(candidate) && candidate.length > 0) {
-        return candidate as Feature[];
-      }
-    }
-    return [];
-  } catch (error) {
-    console.error(`[FEATURE-EXTRACT-ERROR]:`, error);
-    return [];
-  }
+  return extractFeaturesFromBinaryTile(tile);
 }
 
 export function aggregateTileMetrics(tiles: unknown[]) {

--- a/humans-globe/components/footsteps/layers/tooltip.test.ts
+++ b/humans-globe/components/footsteps/layers/tooltip.test.ts
@@ -5,8 +5,8 @@ describe('buildTooltipData', () => {
     const info: PickingInfo = {
       object: {
         properties: { population: 123 },
-        geometry: { coordinates: [1, 2] },
       },
+      coordinate: [1, 2],
       x: 10,
       y: 20,
     };

--- a/humans-globe/components/footsteps/layers/tooltip.ts
+++ b/humans-globe/components/footsteps/layers/tooltip.ts
@@ -1,24 +1,10 @@
-export interface PickingInfo {
-  object?: {
-    properties?: { population?: number };
-    geometry?: { coordinates?: [number, number] };
-  };
-  x?: number;
-  y?: number;
-}
+import {
+  buildTooltipDataFromBinary,
+  type PickingInfo,
+} from '@/lib/binaryTileUtils';
+
+export { type PickingInfo };
 
 export function buildTooltipData(info: PickingInfo, year: number) {
-  if (info?.object) {
-    const f = info.object as {
-      properties?: { population?: number };
-      geometry?: { coordinates?: [number, number] };
-    };
-    const population = f?.properties?.population || 0;
-    const coordinates = (f?.geometry?.coordinates as [number, number]) || [
-      0, 0,
-    ];
-    const clickPosition = { x: info.x || 0, y: info.y || 0 };
-    return { population, coordinates, year, clickPosition };
-  }
-  return null;
+  return buildTooltipDataFromBinary(info, year);
 }

--- a/humans-globe/lib/binaryTileUtils.ts
+++ b/humans-globe/lib/binaryTileUtils.ts
@@ -1,0 +1,50 @@
+import type { PickingInfo as DeckPickingInfo } from '@deck.gl/core';
+
+export interface Feature {
+  properties?: { population?: number };
+  coordinates?: [number, number];
+}
+
+export type PickingInfo = DeckPickingInfo<Feature> & {
+  object?: { properties?: { population?: number } };
+  coordinate?: [number, number];
+  x?: number;
+  y?: number;
+};
+
+export function extractFeaturesFromBinaryTile(tile: unknown): Feature[] {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = tile as any;
+    const source = t?.content?.data || t?.data || t?.content || t;
+    const layer = source?.layers?.['humans'] || source;
+    const length: number = layer?.length || 0;
+    const positions: Float32Array | number[] | undefined = layer?.positions;
+    const properties: Array<{ population?: number }> | undefined =
+      layer?.properties;
+    const features: Feature[] = [];
+    for (let i = 0; i < length; i++) {
+      const coords = positions
+        ? [positions[i * 2], positions[i * 2 + 1]]
+        : undefined;
+      features.push({
+        properties: properties ? properties[i] : undefined,
+        coordinates: coords as [number, number] | undefined,
+      });
+    }
+    return features;
+  } catch (error) {
+    console.error('[BINARY-FEATURES-ERROR]:', error);
+    return [];
+  }
+}
+
+export function buildTooltipDataFromBinary(info: PickingInfo, year: number) {
+  if (info?.object) {
+    const population = info.object.properties?.population || 0;
+    const coordinates = (info.coordinate as [number, number]) || [0, 0];
+    const clickPosition = { x: info.x || 0, y: info.y || 0 };
+    return { population, coordinates, year, clickPosition };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- parse human tiles in binary mode and drop geojson shape handling
- add binaryTileUtils helper for populations and tooltips
- update tile metrics and tooltip logic to use new helper

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a47eff8be08323a49d089ee62cbe15