### PR TITLE
feat: cache natural earth landmask

### DIFF
--- a/footstep-generator/landmask.py
+++ b/footstep-generator/landmask.py
@@ -6,17 +6,30 @@ or network access are unavailable, treats all points as land.
 """
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Optional
 
 _LAND_GEOMETRY = None  # type: Optional[object]
 
-def _try_load_landmask() -> Optional[object]:
-    """Attempt to load a Natural Earth landmask; return prepared geometry or None."""
+_CACHE_DIR = Path(
+    os.environ.get("FOOTSTEPS_CACHE_DIR", Path.home() / ".cache" / "footsteps")
+).expanduser()
+_CACHE_FILE = _CACHE_DIR / "ne_110m_land.geojson"
+
+def _try_load_landmask(refresh: bool = False) -> Optional[object]:
+    """Attempt to load a Natural Earth landmask; return prepared geometry or None.
+
+    If ``refresh`` is True the file is re-downloaded.
+    """
     try:
         import io  # local import
         import requests  # type: ignore
         import geopandas as gpd  # type: ignore
         from shapely.prepared import prep  # type: ignore
+
+        if _CACHE_FILE.exists() and not refresh:
+            return prep(gpd.read_file(_CACHE_FILE).unary_union)
 
         url = (
             "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/"
@@ -24,6 +37,8 @@ def _try_load_landmask() -> Optional[object]:
         )
         resp = requests.get(url, timeout=30)
         resp.raise_for_status()
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        _CACHE_FILE.write_bytes(resp.content)
         return prep(gpd.read_file(io.BytesIO(resp.content)).unary_union)
     except Exception:
         # Any failure (network or deps) -> fallback
@@ -32,6 +47,14 @@ def _try_load_landmask() -> Optional[object]:
 
 # Try to load at import time, but silently allow fallback
 _LAND_GEOMETRY = _try_load_landmask()
+
+
+def refresh_landmask_cache() -> bool:
+    """Force refresh of cached landmask; return True on success."""
+
+    global _LAND_GEOMETRY
+    _LAND_GEOMETRY = _try_load_landmask(refresh=True)
+    return _LAND_GEOMETRY is not None
 
 
 def is_land(lat: float, lon: float) -> bool:


### PR DESCRIPTION
## Summary
- cache Natural Earth landmask in a configurable directory to avoid repeated downloads
- allow forcing a redownload via `refresh_landmask_cache`

## Testing
- `poetry run isort footstep-generator/landmask.py`
- `poetry run black footstep-generator/landmask.py`
- `poetry run flake8 footstep-generator/landmask.py`
- `poetry run mypy footstep-generator/landmask.py`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8656082188323b1253eb4ad421d4e