### PR TITLE
chore: streamline pnpm caching in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,25 +36,14 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
+        cache: 'pnpm'
+        cache-dependency-path: footsteps-web/pnpm-lock.yaml
         
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
         version: 10
-        
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-        
-    - name: Setup pnpm cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('footsteps-web/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
-          
+
     - name: Install dependencies
       working-directory: ./footsteps-web
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- remove manual pnpm store and cache steps from deploy workflow
- enable pnpm caching via setup-node

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run black footstep-generator --check` *(fails: would reformat 31 files)*
- `poetry run isort footstep-generator --check-only` *(fails: imports are incorrectly sorted)*
- `poetry run pytest footstep-generator -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a865b5b27c8323a6be6304a228f871