### PR TITLE
chore: remove build step from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,10 +59,6 @@ jobs:
       working-directory: ./footsteps-web
       run: pnpm install --frozen-lockfile
       
-    - name: Build application
-      working-directory: ./footsteps-web
-      run: pnpm build
-      
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
       with:


### PR DESCRIPTION
## Summary
- remove redundant `pnpm build` step in deploy workflow so Cloud Build handles the build

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `poetry run black footstep-generator`
- `poetry run isort footstep-generator`
- `poetry run pytest footstep-generator -q`


------
https://chatgpt.com/codex/tasks/task_e_68a865ba15808323b05dc77e6bc39c34