### PR TITLE
ci: cache terraform directories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,8 +81,18 @@ jobs:
       with:
         terraform_version: 1.8.5
 
+    - name: Cache Terraform
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.terraform.d/plugin-cache
+          iac/.terraform
+        key: ${{ runner.os }}-terraform-${{ hashFiles('iac/**/*.tf') }}
+
     - name: Apply Terraform
       working-directory: ./iac
+      env:
+        TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
       run: |
         terraform init
         terraform apply -auto-approve


### PR DESCRIPTION
## Summary
- cache Terraform artifacts to speed up deploy

## Testing
- `poetry run pytest footstep-generator -q`
- `cd footsteps-web && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a865bfcb008323abd40a6a113c7815