### PR TITLE
chore: tag Docker image with latest during Cloud Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,7 @@ jobs:
         # Use --async and poll status to avoid log streaming permission issues
         BUILD_ID=$(gcloud builds submit \
           --tag "$IMAGE_TAG" \
+          --tag "gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}:latest" \
           --timeout=10m \
           --format='value(id)' \
           --async \
@@ -125,12 +126,7 @@ jobs:
           exit 1
         fi
           
-        # Also tag as latest for consistency
-        gcloud container images add-tag --quiet \
-          "$IMAGE_TAG" \
-          "gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}:latest"
-
-    # Cache warmer image build removed (deprecated)
+        # Cache warmer image build removed (deprecated)
           
     - name: Deploy to Cloud Run
       run: |


### PR DESCRIPTION
## Summary
- Tag Cloud Build image with both commit SHA and `latest`
- Drop separate `gcloud container images add-tag` step

## Testing
- `pnpm lint`
- `pnpm test`
- `poetry run pytest footstep-generator -q`

------
https://chatgpt.com/codex/tasks/task_e_68a865cdcd4483238eed291d98bf0176