### PR TITLE
chore: add robots.txt for web crawlers

### DIFF
--- a/footsteps-web/public/robots.txt
+++ b/footsteps-web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /admin


### PR DESCRIPTION
## Summary
- add basic robots.txt disallowing admin area

## Testing
- `pnpm lint`
- `pnpm test`
- `curl -I http://localhost:4444/robots.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a86b755c608323ab4dd98ef362279f