### PR TITLE
feat: add security headers

### DIFF
--- a/footsteps-web/next.config.js
+++ b/footsteps-web/next.config.js
@@ -1,4 +1,20 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'",
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   // Enable standalone output for Docker deployment
@@ -11,6 +27,14 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
   // Removed experimental.esmExternals as recommended by Next.js
   webpack: (config) => {
     // Handle deck.gl dependencies
@@ -18,11 +42,11 @@ const nextConfig = {
       ...config.resolve.alias,
       '@deck.gl/core': require.resolve('@deck.gl/core'),
       '@deck.gl/layers': require.resolve('@deck.gl/layers'),
-      '@deck.gl/react': require.resolve('@deck.gl/react')
+      '@deck.gl/react': require.resolve('@deck.gl/react'),
     };
-    
+
     return config;
-  }
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add Content-Security-Policy, X-Content-Type-Options and X-Frame-Options headers via Next.js config

## Testing
- `pnpm lint`
- `pnpm test`
- `curl -I http://127.0.0.1:4444`

------
https://chatgpt.com/codex/tasks/task_e_68a86b8150108323ac8468f6b9b602ef