### PR TITLE
test: remove CLI integration test

### DIFF
--- a/footstep-generator/tests/test_integration.py
+++ b/footstep-generator/tests/test_integration.py
@@ -4,12 +4,13 @@ Integration test for the complete HYDE processing pipeline with LODs.
 Tests the full workflow without requiring actual HYDE data files.
 """
 
-import sys
 import os
+import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import tempfile
 import pathlib
+import tempfile
 from unittest.mock import patch
 
 from models import LODLevel, ProcessingResult
@@ -24,7 +25,7 @@ yllcorner     -90
 cellsize      0.083333333
 NODATA_value  -9999
 """
-    
+
     # Create small grid with some population data
     data_rows = []
     for i in range(10):  # Just 10 rows for testing
@@ -37,77 +38,81 @@ NODATA_value  -9999
             else:
                 row_data.append("-9999")  # No data
         data_rows.append(" ".join(row_data))
-    
+
     return header + "\n".join(data_rows)
 
 
 def test_integration_workflow():
     """Test the complete integration workflow."""
     print("🔧 Testing integration workflow with mock data...")
-    
+
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = pathlib.Path(temp_dir)
-        
+
         # Create mock ASC file
         asc_file = temp_path / "popd_1000AD.asc"
-        with open(asc_file, 'w') as f:
+        with open(asc_file, "w") as f:
             f.write(create_mock_asc_content())
-        
+
         print(f"  ✓ Created mock ASC file: {asc_file}")
-        
+
         # Create output directory
         output_dir = temp_path / "processed"
         output_dir.mkdir()
-        
+
         # Mock the ascii_grid_to_dots function to return test data
-        def mock_ascii_grid_to_dots(asc_file, year, people_per_dot=100, lod_processor=None):
+        def mock_ascii_grid_to_dots(
+            asc_file, year, people_per_dot=100, lod_processor=None
+        ):
             import geopandas as gpd
             from shapely.geometry import Point
-            
+
             # Create some test dots
             test_dots = []
             test_populations = []
-            
+
             for i in range(5):
                 lon = -50 + (i * 25)  # Spread across longitudes
-                lat = 10 + (i * 10)   # Spread across latitudes
-                pop = 500 + (i * 200) # Varying populations
-                
+                lat = 10 + (i * 10)  # Spread across latitudes
+                pop = 500 + (i * 200)  # Varying populations
+
                 test_dots.append(Point(lon, lat))
                 test_populations.append(pop)
-            
-            gdf = gpd.GeoDataFrame({
-                'population': test_populations,
-                'year': year,
-                'type': 'settlement',
-                'geometry': test_dots
-            }, crs='EPSG:4326')
-            
+
+            gdf = gpd.GeoDataFrame(
+                {
+                    "population": test_populations,
+                    "year": year,
+                    "type": "settlement",
+                    "geometry": test_dots,
+                },
+                crs="EPSG:4326",
+            )
+
             return gdf
-        
+
         # Import and patch the function
         from process_hyde import process_year_with_hierarchical_lods
-        
-        with patch('process_hyde.ascii_grid_to_dots', side_effect=mock_ascii_grid_to_dots):
+
+        with patch(
+            "process_hyde.ascii_grid_to_dots", side_effect=mock_ascii_grid_to_dots
+        ):
             # Test the hierarchical LOD processing
             result = process_year_with_hierarchical_lods(
-                str(asc_file), 
-                1000, 
-                str(output_dir),
-                people_per_dot=100
+                str(asc_file), 1000, str(output_dir), people_per_dot=100
             )
-            
+
             print(f"  ✓ Processed year 1000 with result type: {type(result)}")
-            
+
             # Validate result structure
             assert isinstance(result, ProcessingResult)
             assert result.year == 1000
             assert result.total_population > 0
             assert isinstance(result.lod_data, dict)
-            
+
             print(f"  ✓ Total population: {result.total_population}")
             print(f"  ✓ LOD levels generated: {len(result.lod_data)}")
-            
+
             # Tiles-only: verify no NDJSON files are written
             ndjson_files = list(output_dir.glob("*.ndjson.gz"))
             assert (
@@ -131,51 +136,26 @@ def test_integration_workflow():
                 lod_sum = sum(s.total_population for s in result.lod_data[key])
                 assert 0.99 <= (lod_sum / expected_total) <= 1.01
             print("  ✓ LOD data present and conserves population")
-        
+
         print("✅ Integration workflow test passed!")
         return True
-
-
-def test_command_line_interface():
-    """Test the command line interface logic."""
-    print("🖥️ Testing CLI interface...")
-    
-    # Test argument parsing logic
-    import sys
-    from unittest.mock import patch
-    
-    # Test basic script execution (no args needed, LOD is default)
-    test_args = ['process_hyde.py']
-    
-    with patch.object(sys, 'argv', test_args):
-        # This tests the basic script execution
-        import process_hyde
-        
-        # Since LOD processing is now default, no args needed
-        print("  ✓ LOD processing is now default (no flags required)")
-    
-    print("✅ CLI interface test passed!")
-    return True
 
 
 if __name__ == "__main__":
     try:
         print("🚀 Starting integration tests...\n")
-        
+
         # Run integration workflow test
         test_integration_workflow()
         print()
-        
-        # Run CLI interface test
-        test_command_line_interface()
-        print()
-        
-        print("🎉 All integration tests passed!")
+
+        print("🎉 Integration workflow test passed!")
         print("📝 The complete pipeline is ready for production use.")
         print("📝 Run with real data: python process_hyde.py")
-        
+
     except Exception as e:
         print(f"❌ Integration test failed: {e}")
         import traceback
+
         traceback.print_exc()
         exit(1)


### PR DESCRIPTION
## Summary
- remove outdated CLI interface test from integration suite
- keep integration workflow test and simplify __main__ block

## Testing
- `poetry run pytest footstep-generator/tests/test_integration.py -q`
- `poetry run mypy footstep-generator/tests/test_integration.py` *(fails: footstep-generator is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68a86beb7138832390bedb08b7305cee