### PR TITLE
fix: stabilize human layer cache

### DIFF
--- a/footsteps-web/components/footsteps/FootstepsViz.tsx
+++ b/footsteps-web/components/footsteps/FootstepsViz.tsx
@@ -47,12 +47,8 @@ function FootstepsViz({ year }: FootstepsVizProps) {
   const [totalPopulation, setTotalPopulation] = useState<number>(0);
   const [yearChangedAt, setYearChangedAt] = useState<number>(() => Date.now());
 
-  const {
-    previousYear,
-    currentOpacity,
-    previousOpacity,
-    newLayerHasTileRef,
-  } = useYearCrossfade(year);
+  const { previousYear, currentOpacity, previousOpacity, newLayerHasTileRef } =
+    useYearCrossfade(year);
 
   // Reset metrics when year changes
   useEffect(() => {
@@ -115,7 +111,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         year,
         stableLODLevel,
         currentOpacity,
-        `human-layer-${year}`,
+        'human-layer-current',
         true,
       ),
     [createHumanLayerForYear, year, stableLODLevel, currentOpacity],
@@ -128,7 +124,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
             previousYear as number,
             stableLODLevel,
             previousOpacity,
-            `human-layer-${previousYear}`,
+            'human-layer-previous',
             false,
           )
         : null,

--- a/footsteps-web/components/footsteps/layers/humanLayer.ts
+++ b/footsteps-web/components/footsteps/layers/humanLayer.ts
@@ -3,7 +3,7 @@ import { MVTLayer } from '@deck.gl/geo-layers';
 import { getTileUrlPattern } from '@/lib/tilesConfig';
 import { radiusStrategies, type RadiusStrategy } from './radiusStrategies';
 import { getPointRadius } from './radius';
-import { createLayerId, createOnTileLoadHandler } from './tileCache';
+import { createOnTileLoadHandler } from './tileCache';
 import { getFillColor } from './color';
 import { buildTooltipData, type PickingInfo } from './tooltip';
 import { getWorkerManager } from './WorkerManager';
@@ -49,8 +49,8 @@ export function createHumanTilesLayer(
   const tileOptions =
     (extra && 'tileOptions' in extra ? extra.tileOptions : undefined) || {};
 
-  // Generate unique layer ID to prevent deck.gl assertion failures from layer reuse
-  const layerId = createLayerId(year, radiusStrategy, instanceId);
+  // Use a stable layer id so deck.gl can reuse tile cache across year changes
+  const layerId = instanceId || `human-tiles-${radiusStrategy.getName()}`;
   const zoomRange = { min: 0, max: 12 };
 
   return new MVTLayer({
@@ -61,8 +61,8 @@ export function createHumanTilesLayer(
     // Use best-available refinement to ensure tiles load
     refinementStrategy: 'best-available',
     // Set reasonable defaults for tile loading
-    maxCacheSize: tileOptions.maxCacheSize ?? 100,
-    maxCacheByteSize: tileOptions.maxCacheByteSize ?? 32 * 1024 * 1024, // 32MB
+    maxCacheSize: tileOptions.maxCacheSize ?? 300,
+    maxCacheByteSize: tileOptions.maxCacheByteSize ?? 64 * 1024 * 1024, // 64MB
     debounceTime: tileOptions.debounceTime ?? 0, // No debounce by default
     maxRequests: tileOptions.maxRequests ?? 6,
     zoomOffset: tileOptions.zoomOffset ?? 0,


### PR DESCRIPTION
## Summary
- increase human MVT layer cache limits to 300 tiles / 64MB
- use stable layer IDs so Deck.GL reuses tile caches across years
- ensure FootstepsViz uses consistent IDs for current and previous year layers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86e2f796c8323a869914bac31359b