### PR TITLE
feat: make container concurrency configurable

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -117,6 +117,8 @@ resource "google_cloud_run_v2_service" "app" {
       max_instance_count = var.max_instances
     }
 
+    max_instance_request_concurrency = var.container_concurrency
+
     containers {
       image = var.container_image
 

--- a/iac/terraform.tfvars.example
+++ b/iac/terraform.tfvars.example
@@ -12,6 +12,10 @@ container_image = "gcr.io/footsteps-earth/footsteps-time-app:latest"
 min_instances = 0  # Set to 0 for cost optimization
 max_instances = 100
 
+# Concurrency settings
+# Increase for I/O-bound workloads; lower for CPU-bound tasks
+container_concurrency = 80
+
 # Resource limits
 cpu_limit      = "2000m"  # 2 vCPUs
 memory_limit   = "2Gi"    # 2GB memory

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -46,6 +46,12 @@ variable "max_instances" {
   default     = 100
 }
 
+variable "container_concurrency" {
+  description = "Maximum concurrent requests per container instance"
+  type        = number
+  default     = 80
+}
+
 variable "cpu_limit" {
   description = "CPU limit for Cloud Run service"
   type        = string


### PR DESCRIPTION
## Summary
- add `container_concurrency` variable for Cloud Run
- set `max_instance_request_concurrency` from `container_concurrency`
- document concurrency tuning guidance for I/O-bound workloads

## Testing
- `terraform -chdir=iac fmt`
- `terraform -chdir=iac init -backend=false` *(fails: could not connect to registry)*
- `terraform -chdir=iac validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3c36f7fc83238eec4a7d7974dcdb