### PR TITLE
feat: enable continuous year interpolation

### DIFF
--- a/footsteps-web/app/interpolation/page.tsx
+++ b/footsteps-web/app/interpolation/page.tsx
@@ -9,11 +9,12 @@ import { useState } from 'react';
 export default function InterpolationDemo() {
   const [enableInterpolation, setEnableInterpolation] = useState(true);
   const [isDragging, setIsDragging] = useState(false);
-  
-  const { 
-    year, 
+
+  const {
+    year,
     targetYear,
-    sliderValue, 
+    sliderValue,
+    updateYear,
     updateSlider,
     updateSliderContinuous,
     formattedYear,
@@ -53,28 +54,35 @@ export default function InterpolationDemo() {
     <main className="relative w-full h-screen overflow-hidden bg-black">
       <ErrorBoundary>
         {/* Globe visualization with interpolation */}
-        <FootstepsVizWithInterpolation 
-          year={year} 
+        <FootstepsVizWithInterpolation
+          year={year}
           enableInterpolation={enableInterpolation}
           interpolationThreshold={50}
+          manualInterpolation={
+            shouldInterpolate
+              ? {
+                  fromYear: interpolationFromYear,
+                  toYear: interpolationToYear,
+                  t: interpolationProgress,
+                }
+              : undefined
+          }
         />
       </ErrorBoundary>
-      
+
       {/* Enhanced time control slider */}
       <div className="relative">
-        <TimeSlider 
-          value={sliderValue} 
+        <TimeSlider
+          value={sliderValue}
           onChange={handleSliderChange}
           onBeforeChange={handleBeforeChange}
           onAfterChange={handleAfterChange}
         />
-        
+
         {/* Current year display - show the animated year */}
         <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-4 text-center pointer-events-none">
           <div className="bg-black bg-opacity-60 px-4 py-2 rounded-lg">
-            <div className="text-white text-2xl font-bold">
-              {formattedYear}
-            </div>
+            <div className="text-white text-2xl font-bold">{formattedYear}</div>
             {isAnimating && (
               <div className="text-white text-xs opacity-75 mt-1">
                 Animating to {targetYear}...
@@ -83,11 +91,13 @@ export default function InterpolationDemo() {
           </div>
         </div>
       </div>
-      
+
       {/* Controls panel */}
       <div className="absolute top-4 left-4 z-10 bg-black bg-opacity-50 text-white p-3 rounded-lg">
-        <h3 className="text-lg font-bold mb-2">Population Interpolation Demo</h3>
-        
+        <h3 className="text-lg font-bold mb-2">
+          Population Interpolation Demo
+        </h3>
+
         <label className="flex items-center mb-2 cursor-pointer">
           <input
             type="checkbox"
@@ -97,34 +107,38 @@ export default function InterpolationDemo() {
           />
           Enable Interpolation
         </label>
-        
+
         <div className="text-xs text-gray-300 space-y-1">
           <div>Current Year: {year}</div>
           <div>Target Year: {targetYear}</div>
           <div>Animating: {isAnimating ? 'Yes' : 'No'}</div>
           {shouldInterpolate && (
             <>
-              <div>Interpolation: {interpolationFromYear} → {interpolationToYear}</div>
+              <div>
+                Interpolation: {interpolationFromYear} → {interpolationToYear}
+              </div>
               <div>Progress: {Math.round(interpolationProgress * 100)}%</div>
             </>
           )}
           <div>Dragging: {isDragging ? 'Yes' : 'No'}</div>
         </div>
-        
+
         <div className="mt-3 pt-2 border-t border-gray-600 text-xs text-gray-400">
-          <p><strong>Instructions:</strong></p>
+          <p>
+            <strong>Instructions:</strong>
+          </p>
           <p>• Click on distant years to see smooth interpolation</p>
           <p>• Drag slider for immediate scrubbing</p>
           <p>• Toggle interpolation on/off to compare</p>
         </div>
       </div>
-      
+
       {/* Quick jump buttons for testing */}
       <div className="absolute bottom-20 right-4 z-10 flex flex-col gap-2">
         {[-10000, -5000, -1000, 0, 500, 1000].map((testYear) => (
           <button
             key={testYear}
-            onClick={() => updateSlider(testYear)}
+            onClick={() => updateYear(testYear)}
             className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded text-sm"
             disabled={isAnimating}
           >

--- a/footsteps-web/app/page.tsx
+++ b/footsteps-web/app/page.tsx
@@ -1,33 +1,74 @@
 'use client';
 
-import { useYear } from '../lib/useYear';
-import FootstepsViz from '../components/footsteps/FootstepsViz';
+import { useState } from 'react';
+import { useYearWithInterpolation } from '../lib/useYearWithInterpolation';
+import FootstepsVizWithInterpolation from '../components/footsteps/FootstepsVizWithInterpolation';
 import TimeSlider from '../components/ui/TimeSlider';
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
 
 export default function Home() {
-  const { year, sliderValue, updateSlider } = useYear(-1000); // Start at 1000 BC (we know this data exists)
-  
+  const [isDragging, setIsDragging] = useState(false);
+
+  const {
+    year,
+    sliderValue,
+    updateSlider,
+    updateSliderContinuous,
+    stopAnimation,
+    shouldInterpolate,
+    interpolationFromYear,
+    interpolationToYear,
+    interpolationProgress,
+  } = useYearWithInterpolation(-1000, {
+    enableInterpolation: true,
+    interpolationThreshold: 50,
+    autoAnimateThreshold: 200,
+    animationDurationMs: 2000,
+  });
+
+  const handleSliderChange = (value: number) => {
+    if (isDragging) {
+      updateSliderContinuous(value);
+    } else {
+      updateSlider(value);
+    }
+  };
+
+  const handleBeforeChange = () => {
+    setIsDragging(true);
+    stopAnimation();
+  };
+
+  const handleAfterChange = () => {
+    setIsDragging(false);
+  };
+
   return (
     <main className="relative w-full h-screen overflow-hidden bg-black">
       <ErrorBoundary>
-        {/* Globe visualization - now with React 18 compatibility */}
-        <FootstepsViz year={year} />
+        {/* Globe visualization */}
+        <FootstepsVizWithInterpolation
+          year={year}
+          enableInterpolation={true}
+          manualInterpolation={
+            shouldInterpolate
+              ? {
+                  fromYear: interpolationFromYear,
+                  toYear: interpolationToYear,
+                  t: interpolationProgress,
+                }
+              : undefined
+          }
+        />
       </ErrorBoundary>
-      
+
       {/* Time control slider */}
-      <TimeSlider 
-        value={sliderValue} 
-        onChange={updateSlider}
+      <TimeSlider
+        value={sliderValue}
+        onChange={handleSliderChange}
+        onBeforeChange={handleBeforeChange}
+        onAfterChange={handleAfterChange}
       />
-      
-      {/* Branding indicator - only show when not loading */}
-      {/* <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none">
-        <div className="text-white/50 text-center">
-          <div className="text-2xl font-bold mb-2">Globe of Humans</div>
-          <div className="text-sm">React 18 Compatible</div>
-        </div>
-      </div> */}
     </main>
   );
 }

--- a/footsteps-web/components/ui/TimeSlider.tsx
+++ b/footsteps-web/components/ui/TimeSlider.tsx
@@ -6,7 +6,7 @@ import useSliderMarks from './hooks/useSliderMarks';
 
 /**
  * Time navigation component for scrubbing through historical years.
- * 
+ *
  * Follows design philosophy:
  * - Hero interaction: "Dragging should feel like controlling time itself"
  * - Immediate impact: Current year display as the dominant visual element
@@ -24,11 +24,19 @@ interface TimeSliderProps {
   onAfterChange?: () => void;
 }
 
-export default function TimeSlider({ value, onChange, onBeforeChange, onAfterChange }: TimeSliderProps) {
+export default function TimeSlider({
+  value,
+  onChange,
+  onBeforeChange,
+  onAfterChange,
+}: TimeSliderProps) {
   const [isDragging, setIsDragging] = useState(false);
-  const handleSelectMark = useCallback((pos: number) => {
-    onChange(pos);
-  }, [onChange]);
+  const handleSelectMark = useCallback(
+    (pos: number) => {
+      onChange(pos);
+    },
+    [onChange],
+  );
   const marks = useSliderMarks(value, handleSelectMark);
 
   // rAF-throttled change handler to maintain smooth 60fps scrubbing
@@ -87,8 +95,8 @@ export default function TimeSlider({ value, onChange, onBeforeChange, onAfterCha
             onBeforeChange={handleBeforeChange}
             onAfterChange={handleAfterChange}
             marks={marks}
-            step={null}
-            dots={true}
+            step={0.1}
+            dots={false}
             included={true}
             className="time-slider w-full"
             aria-label="Time slider"

--- a/footsteps-web/lib/useYear.ts
+++ b/footsteps-web/lib/useYear.ts
@@ -72,6 +72,24 @@ function getYearFromScaledPosition(position: number): number {
   return Math.round(year);
 }
 
+// Non-snapping version returning fractional year for interpolation
+export function sliderToYearContinuous(position: number): number {
+  const clamped = Math.min(Math.max(position, 0), 100);
+  const minYear = MIN_YEAR;
+  const maxYear = MAX_YEAR;
+  const maxYearsAgo = maxYear - minYear;
+  const compressionFactor = COMPRESSION_FACTOR;
+  const positionRatio = clamped / 100;
+  const rawPos = positionRatio * RAW_MAX_POSITION;
+  const logPositionRatio = rawPos / RAW_MAX_POSITION;
+  const logMaxYearsAgo = Math.log(maxYearsAgo + compressionFactor);
+  const logYearsAgo = (1 - logPositionRatio) * logMaxYearsAgo;
+  let yearsAgo = Math.exp(logYearsAgo) - compressionFactor;
+  if (yearsAgo < 0) yearsAgo = 0;
+  const year = maxYear - yearsAgo;
+  return year;
+}
+
 // Convert slider position (0-100) to year (snaps to available target years)
 export function sliderToYear(position: number): number {
   const clamped = Math.min(Math.max(position, 0), 100);

--- a/footsteps-web/lib/useYearWithInterpolation.ts
+++ b/footsteps-web/lib/useYearWithInterpolation.ts
@@ -2,17 +2,20 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { TARGET_YEARS } from './constants';
-import { formatYear, yearToSlider, sliderToYear } from './useYear';
+import { formatYear, yearToSlider, sliderToYearContinuous } from './useYear';
 
 export { formatYear };
 
 // Enhanced hook that supports smooth interpolation between years
-export function useYearWithInterpolation(initialYear: number = 0, options: {
-  enableInterpolation?: boolean;
-  interpolationThreshold?: number;
-  autoAnimateThreshold?: number; // Threshold for auto-animation on large jumps
-  animationDurationMs?: number;
-} = {}) {
+export function useYearWithInterpolation(
+  initialYear: number = 0,
+  options: {
+    enableInterpolation?: boolean;
+    interpolationThreshold?: number;
+    autoAnimateThreshold?: number; // Threshold for auto-animation on large jumps
+    animationDurationMs?: number;
+  } = {},
+) {
   const {
     enableInterpolation = true,
     interpolationThreshold = 50,
@@ -23,7 +26,7 @@ export function useYearWithInterpolation(initialYear: number = 0, options: {
   const [targetYear, setTargetYear] = useState(initialYear);
   const [sliderValue, setSliderValue] = useState(yearToSlider(initialYear));
   const [isAnimating, setIsAnimating] = useState(false);
-  
+
   // For smooth interpolation during animation
   const [animatedYear, setAnimatedYear] = useState(initialYear);
   const animationRef = useRef<number | null>(null);
@@ -39,87 +42,123 @@ export function useYearWithInterpolation(initialYear: number = 0, options: {
     startTimeRef.current = null;
   }, []);
 
-  const animate = useCallback((timestamp: number, targetYear: number) => {
-    if (!startTimeRef.current) {
-      startTimeRef.current = timestamp;
-    }
+  const animate = useCallback(
+    (timestamp: number, targetYear: number) => {
+      if (!startTimeRef.current) {
+        startTimeRef.current = timestamp;
+      }
 
-    const elapsed = timestamp - startTimeRef.current;
-    const progress = Math.min(elapsed / animationDurationMs, 1);
-    
-    // Smooth easing function
-    const easedProgress = progress * progress * (3 - 2 * progress);
-    
-    const fromYear = fromYearRef.current;
-    const currentYear = fromYear + (targetYear - fromYear) * easedProgress;
-    setAnimatedYear(Math.round(currentYear));
+      const elapsed = timestamp - startTimeRef.current;
+      const progress = Math.min(elapsed / animationDurationMs, 1);
 
-    if (progress < 1) {
-      animationRef.current = requestAnimationFrame((ts) => animate(ts, targetYear));
-    } else {
-      setAnimatedYear(targetYear);
-      setIsAnimating(false);
-      animationRef.current = null;
-      startTimeRef.current = null;
-    }
-  }, [animationDurationMs]);
+      // Smooth easing function
+      const easedProgress = progress * progress * (3 - 2 * progress);
 
-  const startAnimation = useCallback((toYear: number) => {
-    stopAnimation();
-    
-    fromYearRef.current = animatedYear;
-    setIsAnimating(true);
-    startTimeRef.current = null;
-    
-    animationRef.current = requestAnimationFrame((ts) => animate(ts, toYear));
-  }, [animate, animatedYear, stopAnimation]);
+      const fromYear = fromYearRef.current;
+      const currentYear = fromYear + (targetYear - fromYear) * easedProgress;
+      setAnimatedYear(currentYear);
 
-  const updateYear = useCallback((newYear: number) => {
-    const yearDiff = Math.abs(newYear - animatedYear);
-    
-    setTargetYear(newYear);
-    setSliderValue(yearToSlider(newYear));
-    
-    if (enableInterpolation && yearDiff > autoAnimateThreshold && !isAnimating) {
-      startAnimation(newYear);
-    } else {
+      if (progress < 1) {
+        animationRef.current = requestAnimationFrame((ts) =>
+          animate(ts, targetYear),
+        );
+      } else {
+        setAnimatedYear(targetYear);
+        setIsAnimating(false);
+        animationRef.current = null;
+        startTimeRef.current = null;
+      }
+    },
+    [animationDurationMs],
+  );
+
+  const startAnimation = useCallback(
+    (toYear: number) => {
       stopAnimation();
-      setAnimatedYear(newYear);
-    }
-  }, [animatedYear, enableInterpolation, autoAnimateThreshold, isAnimating, startAnimation, stopAnimation]);
 
-  const updateSlider = useCallback((newSliderValue: number) => {
-    const newYear = sliderToYear(newSliderValue);
-    setSliderValue(newSliderValue);
-    
-    const yearDiff = Math.abs(newYear - animatedYear);
-    
-    if (enableInterpolation && yearDiff > interpolationThreshold) {
+      fromYearRef.current = animatedYear;
+      setIsAnimating(true);
+      startTimeRef.current = null;
+
+      animationRef.current = requestAnimationFrame((ts) => animate(ts, toYear));
+    },
+    [animate, animatedYear, stopAnimation],
+  );
+
+  const updateYear = useCallback(
+    (newYear: number) => {
+      const yearDiff = Math.abs(newYear - animatedYear);
+
       setTargetYear(newYear);
-      if (yearDiff > autoAnimateThreshold && !isAnimating) {
+      setSliderValue(yearToSlider(newYear));
+
+      if (
+        enableInterpolation &&
+        yearDiff > autoAnimateThreshold &&
+        !isAnimating
+      ) {
         startAnimation(newYear);
-      } else if (!isAnimating) {
-        // For smaller jumps, update immediately but still allow interpolation layer
+      } else {
+        stopAnimation();
+        setAnimatedYear(newYear);
+      }
+    },
+    [
+      animatedYear,
+      enableInterpolation,
+      autoAnimateThreshold,
+      isAnimating,
+      startAnimation,
+      stopAnimation,
+    ],
+  );
+
+  const updateSlider = useCallback(
+    (newSliderValue: number) => {
+      const newYear = sliderToYearContinuous(newSliderValue);
+      setSliderValue(newSliderValue);
+
+      const yearDiff = Math.abs(newYear - animatedYear);
+
+      if (enableInterpolation && yearDiff > interpolationThreshold) {
+        setTargetYear(newYear);
+        if (yearDiff > autoAnimateThreshold && !isAnimating) {
+          startAnimation(newYear);
+        } else if (!isAnimating) {
+          // For smaller jumps, update immediately but still allow interpolation layer
+          setAnimatedYear(newYear);
+          setTargetYear(newYear);
+        }
+      } else {
+        stopAnimation();
         setAnimatedYear(newYear);
         setTargetYear(newYear);
       }
-    } else {
+    },
+    [
+      animatedYear,
+      enableInterpolation,
+      interpolationThreshold,
+      autoAnimateThreshold,
+      isAnimating,
+      startAnimation,
+      stopAnimation,
+    ],
+  );
+
+  // Handle continuous slider dragging
+  const updateSliderContinuous = useCallback(
+    (newSliderValue: number) => {
+      const newYear = sliderToYearContinuous(newSliderValue);
+      setSliderValue(newSliderValue);
+
+      // During continuous dragging, stop animation and update directly
       stopAnimation();
       setAnimatedYear(newYear);
       setTargetYear(newYear);
-    }
-  }, [animatedYear, enableInterpolation, interpolationThreshold, autoAnimateThreshold, isAnimating, startAnimation, stopAnimation]);
-
-  // Handle continuous slider dragging
-  const updateSliderContinuous = useCallback((newSliderValue: number) => {
-    const newYear = sliderToYear(newSliderValue);
-    setSliderValue(newSliderValue);
-    
-    // During continuous dragging, stop animation and update directly
-    stopAnimation();
-    setAnimatedYear(newYear);
-    setTargetYear(newYear);
-  }, [stopAnimation]);
+    },
+    [stopAnimation],
+  );
 
   // Clean up on unmount
   useEffect(() => {
@@ -130,23 +169,37 @@ export function useYearWithInterpolation(initialYear: number = 0, options: {
     };
   }, []);
 
+  const getBoundingYears = useCallback((year: number) => {
+    let from = TARGET_YEARS[0];
+    let to = TARGET_YEARS[TARGET_YEARS.length - 1];
+    for (const y of TARGET_YEARS) {
+      if (y <= year) from = y;
+      if (y >= year) {
+        to = y;
+        break;
+      }
+    }
+    return { from, to };
+  }, []);
+
+  const { from: interpFrom, to: interpTo } = getBoundingYears(animatedYear);
+  const range = interpTo - interpFrom;
+  const progress = range === 0 ? 0 : (animatedYear - interpFrom) / range;
+
   return {
     year: animatedYear, // The year to actually display
-    targetYear, // The year the user selected
+    targetYear,
     sliderValue,
     updateYear,
     updateSlider,
     updateSliderContinuous, // Use this during active dragging
-    formattedYear: formatYear(animatedYear),
+    formattedYear: formatYear(Math.round(animatedYear)),
     isAnimating,
     stopAnimation,
-    
-    // Interpolation info for the visualization layer
-    shouldInterpolate: enableInterpolation && Math.abs(targetYear - animatedYear) > interpolationThreshold,
-    interpolationFromYear: isAnimating ? fromYearRef.current : animatedYear,
-    interpolationToYear: targetYear,
-    interpolationProgress: isAnimating 
-      ? Math.abs(animatedYear - fromYearRef.current) / Math.abs(targetYear - fromYearRef.current) 
-      : 0,
+
+    shouldInterpolate: enableInterpolation && range > 0 && progress > 0,
+    interpolationFromYear: interpFrom,
+    interpolationToYear: interpTo,
+    interpolationProgress: progress,
   };
 }


### PR DESCRIPTION
## Summary
- allow time slider to scrub between historical years
- compute neighboring year tiles and blend them on the GPU
- wire interpolation into main view and demo page

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68abaa5fd17083239db8dbf7845deef6