### PR TITLE
fix: supply default data to PMTilesTileLayer

### DIFF
--- a/footsteps-web/components/footsteps/layers/humanLayer.ts
+++ b/footsteps-web/components/footsteps/layers/humanLayer.ts
@@ -122,6 +122,7 @@ export function createHumanTilesLayer(
 
   return new PMTilesTileLayer({
     ...commonProps,
+    data: [],
     pmtilesUrl: getPMTilesUrl(year),
   });
 }

--- a/footsteps-web/lib/pmtilesTileLayer.ts
+++ b/footsteps-web/lib/pmtilesTileLayer.ts
@@ -112,7 +112,8 @@ function getPMTiles(url: string): PMTiles {
 
 export class PMTilesTileLayer extends TileLayer<any, PMTilesTileLayerProps> {
   static layerName = 'PMTilesTileLayer';
-  
+  static defaultProps = { ...TileLayer.defaultProps, data: [] };
+
   getTileData = async (tile: any) => {
     const { x, y, z } = tile.index;
     const signal: AbortSignal | undefined = tile?.signal;


### PR DESCRIPTION
## Summary
- default pmtiles layer props include placeholder data to satisfy TileLayer
- supply data property when creating human tiles layer

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b571c6b9588323b95a2923ddbec39b