### PR TITLE
refactor: modularize layers and tooltip overlay

### DIFF
--- a/footsteps-web/components/footsteps/hooks/useBackgroundLayers.ts
+++ b/footsteps-web/components/footsteps/hooks/useBackgroundLayers.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { createSeaLayer, createContinentsLayer, createTerrainLayer } from '@/components/footsteps/layers';
+
+const ENABLE_PLAIN_BASEMAP = (process.env.NEXT_PUBLIC_ENABLE_PLAIN_BASEMAP || 'true') === 'true';
+
+export default function useBackgroundLayers() {
+  const [showTerrain, setShowTerrain] = useState(() => !ENABLE_PLAIN_BASEMAP);
+
+  const backgroundLayers = useMemo(() => {
+    if (!showTerrain) return [createSeaLayer(), createContinentsLayer()];
+    return [createTerrainLayer()];
+  }, [showTerrain]);
+
+  return { backgroundLayers, showTerrain, setShowTerrain } as const;
+}
+

--- a/footsteps-web/components/footsteps/hooks/useHumanLayers.ts
+++ b/footsteps-web/components/footsteps/hooks/useHumanLayers.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import { useMemo } from 'react';
+import { getLODLevel } from '@/lib/lod';
+import { createHumanLayerFactory } from '@/components/footsteps/layers';
+import type { ColorScheme } from '@/components/footsteps/layers/color';
+import type { LayersList } from '@deck.gl/core';
+import useYearCrossfade from '@/components/footsteps/hooks/useYearCrossfade';
+import type { TooltipData } from '@/components/footsteps/overlays/TooltipOverlay';
+
+interface UseHumanLayersProps {
+  year: number;
+  is3DMode: boolean;
+  viewState: { zoom: number };
+  isZooming: boolean;
+  isPanning: boolean;
+  colorScheme: ColorScheme;
+  setTileLoading: (v: boolean) => void;
+  setMetricsLoading: (v: boolean) => void;
+  setFeatureCount: (v: number) => void;
+  setTotalPopulation: (v: number) => void;
+  setTooltipData: (data: TooltipData | null) => void;
+}
+
+export default function useHumanLayers({
+  year,
+  is3DMode,
+  viewState,
+  isZooming,
+  isPanning,
+  colorScheme,
+  setTileLoading,
+  setMetricsLoading,
+  setFeatureCount,
+  setTotalPopulation,
+  setTooltipData,
+}: UseHumanLayersProps) {
+  const { previousYear, currentOpacity, previousOpacity, newLayerHasTileRef } =
+    useYearCrossfade(year);
+
+  const roundedZoom = Math.floor(viewState.zoom);
+  const stableLODLevel = useMemo(() => getLODLevel(roundedZoom), [roundedZoom]);
+
+  const layerViewState = viewState;
+
+  const createHumanLayerForYear = useMemo(
+    () =>
+      createHumanLayerFactory({
+        is3DMode,
+        layerViewState,
+        isZooming,
+        isPanning,
+        newLayerHasTileRef,
+        callbacks: {
+          setTileLoading,
+          setMetricsLoading,
+          setTooltipData,
+        },
+        metrics: {
+          setFeatureCount,
+          setTotalPopulation,
+        },
+        colorScheme,
+      }),
+    [
+      is3DMode,
+      layerViewState,
+      isZooming,
+      isPanning,
+      newLayerHasTileRef,
+      setTileLoading,
+      setMetricsLoading,
+      setTooltipData,
+      setFeatureCount,
+      setTotalPopulation,
+      colorScheme,
+    ],
+  );
+
+  const currentYearLayer = useMemo(
+    () =>
+      createHumanLayerForYear(
+        year,
+        stableLODLevel,
+        currentOpacity,
+        `human-layer-current-${colorScheme}`,
+        true,
+      ),
+    [createHumanLayerForYear, year, stableLODLevel, currentOpacity, colorScheme],
+  );
+
+  const previousYearLayer = useMemo(
+    () =>
+      previousYear !== null
+        ? createHumanLayerForYear(
+            previousYear as number,
+            stableLODLevel,
+            previousOpacity,
+            `human-layer-previous-${colorScheme}`,
+            false,
+          )
+        : null,
+    [
+      createHumanLayerForYear,
+      previousYear,
+      stableLODLevel,
+      previousOpacity,
+      colorScheme,
+    ],
+  );
+
+  const layers: LayersList = previousYearLayer
+    ? ([previousYearLayer, currentYearLayer] as LayersList)
+    : ([currentYearLayer] as LayersList);
+
+  return { layers, stableLODLevel } as const;
+}
+

--- a/footsteps-web/components/footsteps/overlays/PopulationTooltip.tsx
+++ b/footsteps-web/components/footsteps/overlays/PopulationTooltip.tsx
@@ -3,14 +3,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { getTooltipPosition, formatCoordinates } from './tooltipUtils';
 import { getPopulationScale } from '@/lib/format';
-
-interface TooltipData {
-  population: number;
-  coordinates: [number, number];
-  year: number;
-  settlementType?: string;
-  clickPosition: { x: number; y: number };
-}
+import type { TooltipData } from './TooltipOverlay';
 
 interface PopulationTooltipProps {
   data: TooltipData | null;

--- a/footsteps-web/components/footsteps/overlays/TooltipOverlay.tsx
+++ b/footsteps-web/components/footsteps/overlays/TooltipOverlay.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import PopulationTooltip from './PopulationTooltip';
+
+export interface TooltipData {
+  population: number;
+  coordinates: [number, number];
+  year: number;
+  settlementType?: string;
+  clickPosition: { x: number; y: number };
+}
+
+interface TooltipContextValue {
+  setTooltipData: (data: TooltipData | null) => void;
+}
+
+const TooltipContext = createContext<TooltipContextValue | undefined>(undefined);
+
+export function useTooltipOverlay() {
+  const ctx = useContext(TooltipContext);
+  if (!ctx) {
+    throw new Error('useTooltipOverlay must be used within TooltipOverlay');
+  }
+  return ctx.setTooltipData;
+}
+
+export default function TooltipOverlay({ children }: { children: ReactNode }) {
+  const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
+
+  return (
+    <TooltipContext.Provider value={{ setTooltipData }}>
+      {children}
+      <PopulationTooltip
+        data={tooltipData}
+        onClose={() => setTooltipData(null)}
+      />
+    </TooltipContext.Provider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract background layer logic into `useBackgroundLayers`
- introduce `useHumanLayers` hook for human layers and crossfade
- centralize tooltip state via new `TooltipOverlay`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5765a5f4883239afd05fdf8820878