### PR TITLE
refactor: use alias imports for components and lib

### DIFF
--- a/footsteps-web/app/globals.css
+++ b/footsteps-web/app/globals.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 @source "./**/*.{js,ts,jsx,tsx,mdx}";
-@source "../components/**/*.{js,ts,jsx,tsx,mdx}";
+@source "@/components/**/*.{js,ts,jsx,tsx,mdx}";
 @import 'rc-slider/assets/index.css';
 
 :root {

--- a/footsteps-web/app/layout.tsx
+++ b/footsteps-web/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import NetworkIndicator from '../components/ui/NetworkIndicator';
-import ServiceWorkerRegistrar from '../components/ui/ServiceWorkerRegistrar';
+import NetworkIndicator from '@/components/ui/NetworkIndicator';
+import ServiceWorkerRegistrar from '@/components/ui/ServiceWorkerRegistrar';
 
 export const metadata: Metadata = {
   title: 'footsteps',

--- a/footsteps-web/app/page.tsx
+++ b/footsteps-web/app/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useYear } from '../lib/useYear';
-import FootstepsViz from '../components/footsteps/FootstepsViz';
-import TimeSlider from '../components/ui/TimeSlider';
-import { ErrorBoundary } from '../components/common/ErrorBoundary';
+import { useYear } from '@/lib/useYear';
+import FootstepsViz from '@/components/footsteps/FootstepsViz';
+import TimeSlider from '@/components/ui/TimeSlider';
+import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 
 export default function Home() {
   const { year, sliderValue, updateSlider } = useYear(-1000); // Start at 1000 BC (we know this data exists)


### PR DESCRIPTION
## Summary
- replace relative component imports with `@/` alias
- update lib import to use `@/` alias
- adjust Tailwind source path to use alias

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5769447b083239558528ae69d7ae3