### PR TITLE
chore: type global PMTiles cache

### DIFF
--- a/footsteps-web/app/api/tiles/[year]/single/[z]/[x]/[y]/route.ts
+++ b/footsteps-web/app/api/tiles/[year]/single/[z]/[x]/[y]/route.ts
@@ -4,10 +4,9 @@ import { PMTiles, FetchSource, SharedPromiseCache } from 'pmtiles';
 type Params = { params: { year: string; z: string; x: string; y: string } };
 
 // Share PMTiles header/dir promises across requests
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const g: any = globalThis as any;
-const sharedPMCache: SharedPromiseCache = g.__pmtilesApiCache || new SharedPromiseCache(2000);
-g.__pmtilesApiCache = sharedPMCache;
+const sharedPMCache: SharedPromiseCache =
+  globalThis.__pmtilesApiCache ?? new SharedPromiseCache(2000);
+globalThis.__pmtilesApiCache = sharedPMCache;
 
 function getCDNOrigin(): string {
   // Prefer explicit server-side origin for PMTiles; fall back to public var if absolute.

--- a/footsteps-web/types/pmtiles-global.d.ts
+++ b/footsteps-web/types/pmtiles-global.d.ts
@@ -1,0 +1,11 @@
+import type { SharedPromiseCache } from 'pmtiles';
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      __pmtilesApiCache?: SharedPromiseCache;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- declare global `NodeJS.Global` interface for `__pmtilesApiCache`
- use typed `globalThis.__pmtilesApiCache` in tile API route

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5768701c08323aaaa05393ea57453