### PR TITLE
refactor: simplify view mode persistence

### DIFF
--- a/footsteps-web/lib/viewModeStore.ts
+++ b/footsteps-web/lib/viewModeStore.ts
@@ -8,66 +8,40 @@
 const COOKIE_NAME = 'globe-view-mode';
 const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year in seconds
 
-export class ViewModeStore {
-  private static instance: ViewModeStore;
-  
-  private constructor() {}
-  
-  static getInstance(): ViewModeStore {
-    if (!ViewModeStore.instance) {
-      ViewModeStore.instance = new ViewModeStore();
-    }
-    return ViewModeStore.instance;
+/**
+ * Get current view mode from cookie.
+ * Works on both server and client for SSR compatibility.
+ */
+export function getViewMode(): boolean {
+  if (typeof document === 'undefined') {
+    return false; // Default to 2D for server-side rendering
   }
-  
-  /**
-   * Get current view mode from cookie
-   * Works on both server and client for SSR compatibility
-   */
-  getViewMode(): boolean {
-    if (typeof document === 'undefined') {
-      return false; // Default to 2D for server-side rendering
-    }
-    
-    try {
-      const cookieValue = document.cookie
-        .split('; ')
-        .find(row => row.startsWith(`${COOKIE_NAME}=`))
-        ?.split('=')[1];
-      
-      return cookieValue === 'true';
-    } catch (error) {
-      console.warn('Failed to read view mode cookie:', error);
-      return false;
-    }
-  }
-  
-  /**
-   * Set view mode preference in cookie
-   * Only works on client side
-   */
-  setViewMode(is3DMode: boolean): void {
-    if (typeof document === 'undefined') {
-      return; // No-op on server
-    }
-    
-    try {
-      document.cookie = `${COOKIE_NAME}=${is3DMode}; max-age=${COOKIE_MAX_AGE}; path=/; SameSite=Lax`;
-    } catch (error) {
-      console.warn('Failed to set view mode cookie:', error);
-    }
+
+  try {
+    const cookieValue = document.cookie
+      .split('; ')
+      .find(row => row.startsWith(`${COOKIE_NAME}=`))
+      ?.split('=')[1];
+
+    return cookieValue === 'true';
+  } catch (error) {
+    console.warn('Failed to read view mode cookie:', error);
+    return false;
   }
 }
 
 /**
- * Convenience functions for direct use
+ * Set view mode preference in cookie.
+ * Only works on client side.
  */
-export const viewModeStore = ViewModeStore.getInstance();
-
-export function getViewMode(): boolean {
-  return viewModeStore.getViewMode();
-}
-
 export function setViewMode(is3DMode: boolean): void {
-  viewModeStore.setViewMode(is3DMode);
+  if (typeof document === 'undefined') {
+    return; // No-op on server
+  }
+
+  try {
+    document.cookie = `${COOKIE_NAME}=${is3DMode}; max-age=${COOKIE_MAX_AGE}; path=/; SameSite=Lax`;
+  } catch (error) {
+    console.warn('Failed to set view mode cookie:', error);
+  }
 }


### PR DESCRIPTION
## Summary
- replace `ViewModeStore` class with simple `getViewMode`/`setViewMode` functions that read and write the cookie directly
- drop the unused `viewModeStore` singleton

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b576590d408323b3138e76827058ff