### PR TITLE
Ensure lint/type errors fail builds

### DIFF
--- a/footsteps-web/app/api/tiles/[year]/single/[z]/[x]/[y]/route.ts
+++ b/footsteps-web/app/api/tiles/[year]/single/[z]/[x]/[y]/route.ts
@@ -1,7 +1,5 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { PMTiles, FetchSource, SharedPromiseCache } from 'pmtiles';
-
-type Params = { params: { year: string; z: string; x: string; y: string } };
 
 // Share PMTiles header/dir promises across requests
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,12 +27,13 @@ function parseParamInt(v: string, min: number, max: number): number | null {
   return Math.floor(n);
 }
 
-export async function GET(_req: Request, ctx: Params) {
+export async function GET(req: NextRequest) {
   try {
-    const year = Number(ctx.params.year);
-    const z = parseParamInt(ctx.params.z, 0, 22);
-    const x = parseParamInt(ctx.params.x, 0, 1 << 28);
-    const y = parseParamInt(ctx.params.y, 0, 1 << 28);
+    const [, , , yearStr, , zStr, xStr, yStr] = req.nextUrl.pathname.split('/');
+    const year = Number(yearStr);
+    const z = parseParamInt(zStr, 0, 22);
+    const x = parseParamInt(xStr, 0, 1 << 28);
+    const y = parseParamInt(yStr, 0, 1 << 28);
     if (!Number.isFinite(year) || z === null || x === null || y === null) {
       return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
     }

--- a/footsteps-web/next.config.js
+++ b/footsteps-web/next.config.js
@@ -3,14 +3,6 @@ const nextConfig = {
   reactStrictMode: true,
   // Enable standalone output for Docker deployment
   output: 'standalone',
-  // Disable ESLint during build for initial deployment
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  // Disable TypeScript checking during build for initial deployment
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   // Removed experimental.esmExternals as recommended by Next.js
   webpack: (config) => {
     // Handle deck.gl dependencies


### PR DESCRIPTION
## Summary
- remove Next.js build options that skipped ESLint and type checking
- rewrite tile API route to parse params from URL and satisfy type checks

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b576697ddc832385f1fb29023f28b3