### PR TITLE
feat: add env helpers and use them

### DIFF
--- a/footsteps-web/components/footsteps/FootstepsViz.tsx
+++ b/footsteps-web/components/footsteps/FootstepsViz.tsx
@@ -17,8 +17,10 @@ import useGlobeViewState from '@/components/footsteps/hooks/useGlobeViewState';
 import useYearCrossfade from '@/components/footsteps/hooks/useYearCrossfade';
 import VizToggles from '@/components/ui/VizToggles';
 import { type ColorScheme } from '@/components/footsteps/layers/color';
-const DEBUG = (process.env.NEXT_PUBLIC_DEBUG_LOGS || 'false') === 'true';
-const ENABLE_PLAIN_BASEMAP = (process.env.NEXT_PUBLIC_ENABLE_PLAIN_BASEMAP || 'true') === 'true';
+import { isDebugEnabled, isPlainBasemapEnabled, isProduction } from '@/lib/env';
+
+const DEBUG = isDebugEnabled();
+const ENABLE_PLAIN_BASEMAP = isPlainBasemapEnabled();
 
 interface FootstepsVizProps {
   year: number;
@@ -31,7 +33,8 @@ function FootstepsViz({ year }: FootstepsVizProps) {
 
   // Default to terrain unless explicitly enabling the plain basemap via env
   const [showTerrain, setShowTerrain] = useState(() => !ENABLE_PLAIN_BASEMAP);
-  const [colorScheme, setColorScheme] = useState<ColorScheme>(DEFAULT_COLOURSCHEME);
+  const [colorScheme, setColorScheme] =
+    useState<ColorScheme>(DEFAULT_COLOURSCHEME);
 
   const { viewState, onViewStateChange, isZooming, isPanning } =
     useGlobeViewState();
@@ -124,7 +127,13 @@ function FootstepsViz({ year }: FootstepsVizProps) {
         `human-layer-current-${colorScheme}`,
         true,
       ),
-    [createHumanLayerForYear, year, stableLODLevel, currentOpacity, colorScheme],
+    [
+      createHumanLayerForYear,
+      year,
+      stableLODLevel,
+      currentOpacity,
+      colorScheme,
+    ],
   );
 
   const previousYearLayer = useMemo(
@@ -138,7 +147,13 @@ function FootstepsViz({ year }: FootstepsVizProps) {
             false,
           )
         : null,
-    [createHumanLayerForYear, previousYear, stableLODLevel, previousOpacity, colorScheme],
+    [
+      createHumanLayerForYear,
+      previousYear,
+      stableLODLevel,
+      previousOpacity,
+      colorScheme,
+    ],
   );
 
   // Layer ordering: background layers -> settlement points
@@ -146,7 +161,7 @@ function FootstepsViz({ year }: FootstepsVizProps) {
     ? ([...backgroundLayers, previousYearLayer, currentYearLayer] as LayersList)
     : ([...backgroundLayers, currentYearLayer] as LayersList);
 
-  if (process.env.NODE_ENV !== 'production' && DEBUG) {
+  if (!isProduction() && DEBUG) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const logLayer = (layer: any, tag: string, tagYear: number | null) => {

--- a/footsteps-web/components/ui/ServiceWorkerRegistrar.tsx
+++ b/footsteps-web/components/ui/ServiceWorkerRegistrar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { isServiceWorkerEnabled, isDebugEnabled } from '@/lib/env';
 
 export default function ServiceWorkerRegistrar() {
   useEffect(() => {
@@ -8,28 +9,33 @@ export default function ServiceWorkerRegistrar() {
     if (!('serviceWorker' in navigator)) return;
     // Opt-in via env to avoid interfering with browser HTTP cache.
     // Default: do NOT register, so tiles use normal browser/disk cache.
-    const enabled = (process.env.NEXT_PUBLIC_SW_ENABLE || 'false') === 'true';
+    const enabled = isServiceWorkerEnabled();
     if (!enabled) {
       // If a SW was registered previously, proactively unregister it so
       // requests go straight to the network + HTTP cache.
       try {
-        navigator.serviceWorker.getRegistrations().then((regs) => {
-          for (const reg of regs) {
-            reg.unregister().catch(() => {});
-          }
-        }).catch(() => {});
+        navigator.serviceWorker
+          .getRegistrations()
+          .then((regs) => {
+            for (const reg of regs) {
+              reg.unregister().catch(() => {});
+            }
+          })
+          .catch(() => {});
       } catch {}
       return;
     }
 
     const register = async () => {
       try {
-        const reg = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
-        if ((process.env.NEXT_PUBLIC_DEBUG_LOGS || 'false') === 'true') {
+        const reg = await navigator.serviceWorker.register('/sw.js', {
+          scope: '/',
+        });
+        if (isDebugEnabled()) {
           console.debug('[SW] registered', reg.scope);
         }
       } catch (err) {
-        if ((process.env.NEXT_PUBLIC_DEBUG_LOGS || 'false') === 'true') {
+        if (isDebugEnabled()) {
           console.warn('[SW] registration failed', err);
         }
       }

--- a/footsteps-web/lib/env.ts
+++ b/footsteps-web/lib/env.ts
@@ -1,0 +1,81 @@
+// Environment helpers with memoized values
+
+function toBoolean(value: string | undefined, defaultValue = false): boolean {
+  if (value === undefined) return defaultValue;
+  return ['1', 'true', 'yes'].includes(value.toLowerCase());
+}
+
+let debugEnabled: boolean | undefined;
+export function isDebugEnabled(): boolean {
+  if (debugEnabled === undefined) {
+    debugEnabled = toBoolean(process.env.NEXT_PUBLIC_DEBUG_LOGS, false);
+  }
+  return debugEnabled;
+}
+
+let plainBasemapEnabled: boolean | undefined;
+export function isPlainBasemapEnabled(): boolean {
+  if (plainBasemapEnabled === undefined) {
+    plainBasemapEnabled = toBoolean(
+      process.env.NEXT_PUBLIC_ENABLE_PLAIN_BASEMAP,
+      true,
+    );
+  }
+  return plainBasemapEnabled;
+}
+
+let serviceWorkerEnabled: boolean | undefined;
+export function isServiceWorkerEnabled(): boolean {
+  if (serviceWorkerEnabled === undefined) {
+    serviceWorkerEnabled = toBoolean(process.env.NEXT_PUBLIC_SW_ENABLE, false);
+  }
+  return serviceWorkerEnabled;
+}
+
+let nodeEnv: string | undefined;
+export function isProduction(): boolean {
+  if (nodeEnv === undefined) {
+    nodeEnv = process.env.NODE_ENV || 'development';
+  }
+  return nodeEnv === 'production';
+}
+
+let cdnHost: string | undefined;
+export function getCdnHost(): string {
+  if (!cdnHost) {
+    const host =
+      process.env.NEXT_PUBLIC_CDN_HOST || 'https://pmtiles.willhs.me';
+    if (!host) {
+      throw new Error('NEXT_PUBLIC_CDN_HOST must be set (no fallbacks)');
+    }
+    const trimmed = host.replace(/\/+$/, '');
+    if (/^\//.test(trimmed)) {
+      cdnHost = trimmed;
+      return cdnHost;
+    }
+    const hasScheme = /^https?:\/\//i.test(trimmed);
+    const url = hasScheme ? trimmed : `https://${trimmed}`;
+    if (isDebugEnabled()) {
+      try {
+        const u = new URL(url);
+        if (
+          /localhost|127\.|\[::1\]/.test(u.hostname) ||
+          u.pathname.startsWith('/pmtiles')
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[PMTILES] Using a local/proxied base (',
+            url,
+            ') — browser disk cache may be bypassed by the proxy. Prefer a direct CDN host.',
+          );
+        }
+      } catch {
+        // ignore URL parsing errors
+      }
+    }
+    cdnHost = url;
+  }
+  return cdnHost;
+}
+
+export { toBoolean };

--- a/footsteps-web/lib/pmtilesClient.ts
+++ b/footsteps-web/lib/pmtilesClient.ts
@@ -1,28 +1,6 @@
-function getBase(): string {
-  const host = process.env.NEXT_PUBLIC_CDN_HOST || 'https://pmtiles.willhs.me';
-  if (!host) {
-    throw new Error('NEXT_PUBLIC_CDN_HOST must be set (no fallbacks)');
-  }
-  const trimmed = host.replace(/\/+$/, '');
-  // Support relative base (e.g., '/pmtiles') in dev to avoid CORS via Next rewrites
-  if (/^\//.test(trimmed)) {
-    return trimmed; // relative path base
-  }
-  const hasScheme = /^https?:\/\//i.test(trimmed);
-  const url = hasScheme ? trimmed : `https://${trimmed}`;
-  // Warn when using a local proxy path; this can defeat browser HTTP caching
-  try {
-    const u = new URL(url);
-    if ((/localhost|127\.|\[::1\]/.test(u.hostname) || u.pathname.startsWith('/pmtiles')) &&
-        (process.env.NEXT_PUBLIC_DEBUG_LOGS || 'false') === 'true') {
-      // eslint-disable-next-line no-console
-      console.warn('[PMTILES] Using a local/proxied base (', url, ') — browser disk cache may be bypassed by the proxy. Prefer a direct CDN host.');
-    }
-  } catch {}
-  return url;
-}
+import { getCdnHost } from '@/lib/env';
 
 export function getPMTilesUrl(year: number): string {
-  const base = getBase();
+  const base = getCdnHost();
   return `${base}/humans_${year}.pmtiles`;
 }


### PR DESCRIPTION
## Summary
- centralize environment variable parsing and caching
- use env helpers in FootstepsViz, ServiceWorkerRegistrar, pmtiles client

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5769afb5883238b8726a0b5e34e91